### PR TITLE
use caps to parse date

### DIFF
--- a/src/querier.js
+++ b/src/querier.js
@@ -4,7 +4,7 @@ import moment from 'moment'
 
 function queryZuora (deliveryDate, config) {
   let promise = new Promise((resolve, reject) => {
-    const deliveryDay = moment(deliveryDate, 'yyyy-mm-dd').format('dddd')
+    const deliveryDay = moment(deliveryDate, 'YYYY-MM-DD').format('dddd')
     const subsQuery = `
         SELECT 
             RateplanCharge.quantity,


### PR DESCRIPTION
We were using lower case to parse the date, which cause moment to just fall back to today's date.  This meant we always tried to fulfil as if it were tuesday if it were a tuesday when the fulfilment was run, rather than using the given date to work out the day of the week.

@pvighi @AWare 