### PR TITLE
only exclude free days if it's an echo legacy plan

### DIFF
--- a/src/querier.js
+++ b/src/querier.js
@@ -26,7 +26,7 @@ function queryZuora (deliveryDate, config) {
            Product.Name = 'Newspaper Delivery' AND 
            RatePlanCharge.EffectiveStartDate <= '${deliveryDate}' AND
            RatePlanCharge.EffectiveEndDate >= '${deliveryDate}' AND
-           RatePlanCharge.MRR != 0`
+           (RatePlanCharge.MRR != 0 OR ProductRatePlan.FrontendId__c != 'EchoLegacy')`
 
     const holidaySuspensionQuery = `
       SELECT 


### PR DESCRIPTION
Since echo legacy subs are modelled as free days, we have to make sure that we don't fulfil them.  However it is not sensible to prevent people from having free subs in general, so this PR restricts the exclude free condition to echo legacy only.

I've added the frontend id in UAT and tested with some subs, and it seems to work, but we'll need to add the id in prod before we can fulfil. (if we forget, this will cause us to fulfil echo legacy subs every day of the week!!)

@AWare @pvighi @jacobwinch 