### PR TITLE
ignore removed suspensions

### DIFF
--- a/src/querier.js
+++ b/src/querier.js
@@ -38,7 +38,8 @@ function queryZuora (deliveryDate, config) {
        ProductRatePlanCharge.ProductType__c = 'Adjustment' AND 
        RateplanCharge.Name = 'Holiday Credit' AND 
        RatePlanCharge.EffectiveStartDate <= '${deliveryDate}' AND
-       RatePlanCharge.HolidayEnd__c >= '${deliveryDate}'`
+       RatePlanCharge.HolidayEnd__c >= '${deliveryDate}' AND
+       RatePlan.AmendmentType != 'RemoveProduct'`
 
     const options = {
       method: 'POST',


### PR DESCRIPTION
If a suspension rate plan has been removed, we shouldn't take it into account when fulfilling.  This fixes most of the duplicates, however there is one that really does have a duplicate holiday suspension for some reason.

@pvighi @AWare @jacobwinch 