### PR TITLE
Remove quotes from inside fields in the sf fulfilment files for comparison

### DIFF
--- a/src/lib/QuoteRemover.js
+++ b/src/lib/QuoteRemover.js
@@ -1,0 +1,13 @@
+// @flow
+import {Transform} from 'stream'
+
+export default class QuoteRemover extends Transform {
+  _transform (chunk: Buffer | string, encoding: string, callback:()=> void) {
+    let regex = /([^,|^\n])"([^,|^\n])/g
+    // Any quote with a non comma or newline on both sides.
+
+    // Assume that a buffer contains a whole number of fields.
+    this.push(Buffer.from(chunk.toString().replace(regex, "'")))
+    callback()
+  }
+}


### PR DESCRIPTION
Remove quotes so we can check every sf fulfilment without hand fixing it.