### PR TITLE
fixes to checker

### DIFF
--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -368,6 +368,11 @@ Resources:
       Environment:
         Variables:
           'Stage': !Sub ${Stage}
+  checkerLambdaLogGroup:
+    Type: "AWS::Logs::LogGroup"
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${checkerLambda}"
+    DependsOn: checkerLambda
   fulfilmentCheckerMetric:
     Type: AWS::Logs::MetricFilter
     Properties:
@@ -377,7 +382,7 @@ Resources:
         - MetricNamespace: !Sub "${Stage}/fulfilment"
           MetricName: "fulfilmentFileUpdated"
           MetricValue: 1
-
+    DependsOn: checkerLambdaLogGroup
   CheckerScheduledRule:
     Type: "AWS::Events::Rule"
     Properties:
@@ -387,6 +392,7 @@ Resources:
       Targets:
             - Id: !Sub fulfilmentChecker_${Stage}
               Arn: !GetAtt checkerLambda.Arn
+    DependsOn: fulfilmentCheckerMetric
 
   checherSchedulePermission:
     Type: AWS::Lambda::Permission
@@ -409,3 +415,4 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: LessThanThreshold
+    DependsOn: fulfilmentCheckerMetric

--- a/src/checker.js
+++ b/src/checker.js
@@ -17,13 +17,13 @@ export function handler (input: ?any, context: ?any, callback: Function) {
 }
 
 let maxAgeFor = {
-  Mon: 3,
-  Tue: 1,
-  Wed: 1,
-  Thu: 1,
-  Fri: 1,
-  Sat: 1,
-  Sun: 2
+  Mon: 2,
+  Tue: 0,
+  Wed: 0,
+  Thu: 0,
+  Fri: 0,
+  Sat: 0,
+  Sun: 1
 }
 
 function logCheckResult (checkPassed: boolean) {


### PR DESCRIPTION
- create the lambda log group explicity in the cloudformation template so that we can reference it from the log filter. (otherwise it's created the first time the lambda runs )
- fix the max age for fulfilment files in the check. If we assume this checking the fulfilment files for the next day and it will run after the fulfilment state machine then files will tipically be 0 days old except sundays and mondays.

@paulbrown1982 @AWare @jacobwinch 