### PR TITLE
return last modified date on salesforce update api call

### DIFF
--- a/__tests__/salesforce_uploader.js
+++ b/__tests__/salesforce_uploader.js
@@ -17,7 +17,7 @@ jest.mock('../src/lib/storage', () => {
     copyObject: jest.fn(() => Promise.resolve('ok')),
     getObject: (path) => {
       if (validPaths.includes(path)) {
-        return Promise.resolve({Body: 'csv would be here'})
+        return Promise.resolve({Body: 'csv would be here', LastModified: new Date('12/30/2016')})
       } else {
         return Promise.reject({code: 'NoSuchKey'})// eslint-disable-line prefer-promise-reject-errors
       }
@@ -149,7 +149,7 @@ test('should upload to sf and return file data', done => {
     'headers': {
       'Content-Type': 'application/json'
     },
-    'body': '{"message":"ok","files":[{"name":"HOME_DELIVERY_Monday_12_06_2017.csv","id":"documentId"},{"name":"HOME_DELIVERY_Tuesday_13_06_2017.csv","id":"documentId"}]}'
+    'body': '{"message":"ok","files":[{"name":"HOME_DELIVERY_Monday_12_06_2017.csv","id":"documentId","lastModified":"2016-12-30"},{"name":"HOME_DELIVERY_Tuesday_13_06_2017.csv","id":"documentId","lastModified":"2016-12-30"}]}'
   }
   let expectedFulfilments = ['2017-06-12', '2017-06-13']
   handler(input, {}, verify(done, successResponse, expectedFulfilments))

--- a/src/salesforce_uploader.js
+++ b/src/salesforce_uploader.js
@@ -61,10 +61,12 @@ export function handler (input: apiGatewayLambdaInput, context: any, callback: (
     let outputFileName = `HOME_DELIVERY_${dayOfTheWeek}_${dateSuffix}.csv`
     console.log(`uploading ${outputFileName} to ${sfFolder.name}`)
     let uploadResult = await salesforce.uploadDocument(outputFileName, sfFolder, fileData.file.Body)
+    let lastModified = moment(fileData.file.LastModified).format('YYYY-MM-DD')
     await copyToUploadedFolder(stage, fileData.s3Path, outputFileName)
     return Promise.resolve({
       name: outputFileName,
-      id: uploadResult.id
+      id: uploadResult.id,
+      lastModified: lastModified
     })
   }
 


### PR DESCRIPTION
added the last modified date for each file in the api response.
It's a very simple change and it would allow us to let the caller know how old the file is.
We can use this as an extra check to make sure the files are uploaded to sf after the fulfilment process has executed successfully.
sample response : 
```
{
  "message": "ok",
  "files": [
    {
      "name": "HOME_DELIVERY_Tuesday_25_07_2017.csv",
      "id": "015g0000001FmvFAAS",
      "lastModified": "2017-07-24"
    },
    {
      "name": "HOME_DELIVERY_Wednesday_26_07_2017.csv",
      "id": "015g0000001FmvPAAS",
      "lastModified": "2017-07-25"
    },
    {
      "name": "HOME_DELIVERY_Thursday_27_07_2017.csv",
      "id": "015g0000001FmvKAAS",
      "lastModified": "2017-07-26"
    },
    {
      "name": "HOME_DELIVERY_Friday_28_07_2017.csv",
      "id": "015g0000001FmvAAAS",
      "lastModified": "2017-07-26"
    }
  ]
}
```
@AWare @jacobwinch @paulbrown1982 @johnduffell @lmath 