### PR TITLE
Nightly download

### DIFF
--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -332,6 +332,8 @@ Resources:
           Id: !Sub trigger_state_machine-${Stage}-5
           Input: "{ \"deliveryDateDaysFromNow\": 5 }"
           RoleArn: !GetAtt [ fulfilmentTriggerRole, Arn ]
+        - Id: !Sub salesforceDownloader_${Stage}
+          Arn: !GetAtt SalesforceDownloaderLambda.Arn
 
     DependsOn: FulfilmentStateMachine_[STAGE]
 
@@ -392,8 +394,6 @@ Resources:
       Targets:
             - Id: !Sub fulfilmentChecker_${Stage}
               Arn: !GetAtt checkerLambda.Arn
-            - Id: !Sub salesforceDownloader_${Stage}
-              Arn: !GetAtt SalesforceDownloaderLambda.Arn
             - Id: !Sub salesforceComparator_${Stage}
               Arn: !GetAtt ComparatorLambda.Arn
     DependsOn: fulfilmentCheckerMetric

--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -332,13 +332,32 @@ Resources:
           Id: !Sub trigger_state_machine-${Stage}-5
           Input: "{ \"deliveryDateDaysFromNow\": 5 }"
           RoleArn: !GetAtt [ fulfilmentTriggerRole, Arn ]
+    DependsOn: FulfilmentStateMachine_[STAGE]
+
+  SFDownloadScheduledRule:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Description: "Download fulfilment files from Salesforce"
+      ScheduleExpression: "cron(50 14 ? * mon-fri *)"
+      State: "ENABLED"
+      Targets:
         - 
           Arn: !GetAtt SalesforceDownloaderLambda.Arn
           Id: !Sub salesforceDownloader_[STAGE]
-          RoleArn: !GetAtt [ FulfilmentWorkersLambdaRole, Arn ]
 
     DependsOn: FulfilmentStateMachine_[STAGE]
+  SFComparatorScheduledRule:
+    Type: "AWS::Events::Rule"
+    Properties:
+      Description: "Check the fulfilment files match up."
+      ScheduleExpression: "cron(55 14 ? * mon-fri *)"
+      State: "ENABLED"
+      Targets:
+        -
+          Id: !Sub salesforceComparator_${Stage}
+          Arn: !GetAtt ComparatorLambda.Arn
 
+    DependsOn: FulfilmentStateMachine_[STAGE]
   fulfilmentTriggerRole:
     Type: AWS::IAM::Role
     Properties:
@@ -396,16 +415,29 @@ Resources:
       Targets:
             - Id: !Sub fulfilmentChecker_${Stage}
               Arn: !GetAtt checkerLambda.Arn
-            - Id: !Sub salesforceComparator_${Stage}
-              Arn: !GetAtt ComparatorLambda.Arn
-              RoleArn: !GetAtt [ FulfilmentWorkersLambdaRole, Arn ]
     DependsOn: fulfilmentCheckerMetric
 
-  checherSchedulePermission:
+  checkerSchedulePermission:
     Type: AWS::Lambda::Permission
     Properties:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt checkerLambda.Arn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt CheckerScheduledRule.Arn
+
+  sfDownloadSchedulePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt SalesforceDownloaderLambda.Arn
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt CheckerScheduledRule.Arn
+
+  comparatorSchedulePermission:
+    Type: AWS::Lambda::Permission
+    Properties:
+      Action: lambda:InvokeFunction
+      FunctionName: !GetAtt ComparatorLambda.Arn
       Principal: events.amazonaws.com
       SourceArn: !GetAtt CheckerScheduledRule.Arn
 

--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -332,9 +332,10 @@ Resources:
           Id: !Sub trigger_state_machine-${Stage}-5
           Input: "{ \"deliveryDateDaysFromNow\": 5 }"
           RoleArn: !GetAtt [ fulfilmentTriggerRole, Arn ]
-        - Id: !Sub salesforceDownloader_${Stage}
+        - 
           Arn: !GetAtt SalesforceDownloaderLambda.Arn
-          RoleArn: !GettAtt [FulfilmentWorkersLambdaRole, Arn]
+          Id: !Sub salesforceDownloader_[STAGE]
+          RoleArn: !GetAtt [ FulfilmentWorkersLambdaRole, Arn ]
 
     DependsOn: FulfilmentStateMachine_[STAGE]
 
@@ -397,7 +398,7 @@ Resources:
               Arn: !GetAtt checkerLambda.Arn
             - Id: !Sub salesforceComparator_${Stage}
               Arn: !GetAtt ComparatorLambda.Arn
-              RoleArn: !GettAtt [FulfilmentWorkersLambdaRole, Arn]
+              RoleArn: !GetAtt [ FulfilmentWorkersLambdaRole, Arn ]
     DependsOn: fulfilmentCheckerMetric
 
   checherSchedulePermission:

--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -392,6 +392,10 @@ Resources:
       Targets:
             - Id: !Sub fulfilmentChecker_${Stage}
               Arn: !GetAtt checkerLambda.Arn
+            - Id: !Sub salesforceDownloader_${Stage}
+              Arn: !GetAtt SalesforceDownloaderLambda.Arn
+            - Id: !Sub salesforceComparator_${Stage}
+              Arn: !GetAtt ComparatorLambda.Arn
     DependsOn: fulfilmentCheckerMetric
 
   checherSchedulePermission:

--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -334,6 +334,7 @@ Resources:
           RoleArn: !GetAtt [ fulfilmentTriggerRole, Arn ]
         - Id: !Sub salesforceDownloader_${Stage}
           Arn: !GetAtt SalesforceDownloaderLambda.Arn
+          RoleArn: !GettAtt [FulfilmentWorkersLambdaRole, Arn]
 
     DependsOn: FulfilmentStateMachine_[STAGE]
 
@@ -396,6 +397,7 @@ Resources:
               Arn: !GetAtt checkerLambda.Arn
             - Id: !Sub salesforceComparator_${Stage}
               Arn: !GetAtt ComparatorLambda.Arn
+              RoleArn: !GettAtt [FulfilmentWorkersLambdaRole, Arn]
     DependsOn: fulfilmentCheckerMetric
 
   checherSchedulePermission:

--- a/src/comparator.js
+++ b/src/comparator.js
@@ -19,6 +19,10 @@ type customersMap = {[string]:Array<customer>}
 
 const s3 = new AWS.S3({ signatureVersion: 'v4' })
 const sameDay = (a:moment, b:moment) => a.isSame(b, 'day')
+const inFuture: (moment) => boolean = (() => {
+  let now = moment()
+  return (dt: moment) => dt.isAfter(now, 'day')
+})()
 
 function compareSentDates (salesforceCustomersMap:customersMap, guCustomersMap:customersMap):string {
   let dateSF = salesforceCustomersMap[Object.keys(salesforceCustomersMap)[0]][0]['Sent Date']
@@ -74,7 +78,9 @@ async function compare () {
 
   let sfDates: Array<moment> = sfkeys.map(salesforceDate).filter(notEmpty)
   let guDates: Array<moment> = gukeys.map(outputDate).filter(notEmpty)
-  let logDates: Array<moment> = logkeys.map(logDate).filter(notEmpty)
+
+  let logDates: Array<moment> = logkeys.map(logDate).filter(notEmpty).filter(inFuture)
+  // Check all future dated logfiles every time we run, just to make sure we haven't missed an update.
 
   console.log('Found the following salesforce fulfilments', sfDates.map(d => d.format(OUTPUT_DATE_FORMAT)))
   console.log('Found the following fulfilments', guDates.map(d => d.format(OUTPUT_DATE_FORMAT)))


### PR DESCRIPTION
Same as
https://github.com/guardian/fulfilment-lambdas/pull/48

Add the downloader and comparator to the daily run, and recheck the future dated fulfilments.

We might want to run these at a different time, and I need to deploy the cloudformation on CODE