### PR TITLE
Renaming the filter makes it reappear in CODE.

### DIFF
--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -373,7 +373,7 @@ Resources:
       Environment:
         Variables:
           'Stage': !Sub ${Stage}
-  fulfilmentCheckerMetric:
+  fulfilmentCheckerMetricFilter:
     Type: AWS::Logs::MetricFilter
     Properties:
       LogGroupName: !Sub "/aws/lambda/${checkerLambda}"
@@ -392,7 +392,7 @@ Resources:
       Targets:
             - Id: !Sub fulfilmentChecker_${Stage}
               Arn: !GetAtt checkerLambda.Arn
-    DependsOn: fulfilmentCheckerMetric
+    DependsOn: fulfilmentCheckerMetricFilter
 
   checherSchedulePermission:
     Type: AWS::Lambda::Permission
@@ -415,4 +415,4 @@ Resources:
       EvaluationPeriods: 1
       Threshold: 1
       ComparisonOperator: LessThanThreshold
-    DependsOn: fulfilmentCheckerMetric
+    DependsOn: fulfilmentCheckerMetricFilter


### PR DESCRIPTION
I don't know why either.

Before, the MetricFilter appeared as a thing that the CloudFormation stack had created, but could not be described by any of the AWS tools.