### PR TITLE
Point lambda runner rule policies at the correct rules.

### DIFF
--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -431,7 +431,7 @@ Resources:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt SalesforceDownloaderLambda.Arn
       Principal: events.amazonaws.com
-      SourceArn: !GetAtt CheckerScheduledRule.Arn
+      SourceArn: !GetAtt SFDownloaderScheduledRule.Arn
 
   comparatorSchedulePermission:
     Type: AWS::Lambda::Permission
@@ -439,7 +439,7 @@ Resources:
       Action: lambda:InvokeFunction
       FunctionName: !GetAtt ComparatorLambda.Arn
       Principal: events.amazonaws.com
-      SourceArn: !GetAtt CheckerScheduledRule.Arn
+      SourceArn: !GetAtt SFComparatorScheduledRule.Arn
 
   CheckerAlarm:
     Type: "AWS::CloudWatch::Alarm"


### PR DESCRIPTION
This fixes (in CODE) triggering the comparator lambda. 
The downloader is quite happy to run with the wrong policy- but is also fixed.