### PR TITLE
replace dots with empty strings for first names in home delivery

### DIFF
--- a/__tests__/resources/CODE/zuoraExport/Subscriptions_2017-07-06.csv
+++ b/__tests__/resources/CODE/zuoraExport/Subscriptions_2017-07-06.csv
@@ -1,6 +1,6 @@
 RatePlanCharge.Quantity,Subscription.Name,SoldToContact.Address1,SoldToContact.Address2,SoldToContact.City,SoldToContact.Country,SoldToContact.Title__c,SoldToContact.FirstName,SoldToContact.LastName,SoldToContact.PostalCode,SoldToContact.State,SoldToContact.WorkPhone,SoldToContact.SpecialDeliveryInstructions__c
 1,A-S00062593,92 York Way,92 York Way,London,United Kingdom,Mr,uABT7JsOnyAiFqwao1c,uABT7JsOnyAiFqwao1c,NW1A 1AA,,,
-1,A-S00062368,123 Fake Street,123 Fake Street,Faketown,United Kingdom,Miss,DNVdgozI30Qh47okU1c,DNVdgozI30Qh47okU1c,123 123,,,
+1,A-S00062368,123 Fake Street,123 Fake Street,Faketown,United Kingdom,Miss,.,DNVdgozI30Qh47okU1c,123 123,,,
 1,A-S00062346,test billing address line 1,,test billing town,United Kingdom,,NJvKOa0dGdiAp0uRU1c,NJvKOa0dGdiAp0uRU1c,PE7 1LQ,,,
 1,A-S00069777,1 STREEET,,London,United Kingdom,Mr,HQQ1rY8A1kowTKg7NDc,HQQ1rY8A1kowTKg7NDc,A4 1AA,Greater London,3213213213,
 1,A-S00069850,"The Guardian Media Group, Kings Place, 90 York Way","The Guardian Media Group, Kings Place, 90 York Way",London,United Kingdom,,FX7Y6THUdmHsp7WLcDc,FX7Y6THUdmHsp7WLcDc,N1 9GU,,,

--- a/__tests__/resources/expected/2017-07-06_HOME_DELIVERY.csv
+++ b/__tests__/resources/expected/2017-07-06_HOME_DELIVERY.csv
@@ -1,6 +1,6 @@
 Customer Reference,Contract ID,Customer Full Name,Customer Job Title,Customer Company,Customer Department,Customer Address Line 1,Customer Address Line 2,Customer Address Line 3,Customer Town,Customer PostCode,Delivery Quantity,Customer Telephone,Property type,Front Door Access,Door Colour,House Details,Where to Leave,Landmarks,Additional Information,Letterbox,Source campaign,Sent Date,Delivery Date,Returned Date,Delivery problem,Delivery problem notes,Charge day
 A-S00062593,,uABT7JsOnyAiFqwao1c uABT7JsOnyAiFqwao1c,,,,92 York Way,92 York Way,,London,NW1A 1AA,1,,,,,,,,,,,05/07/2017,06/07/2017,,,,Thursday
-A-S00062368,,DNVdgozI30Qh47okU1c DNVdgozI30Qh47okU1c,,,,123 Fake Street,123 Fake Street,,Faketown,123 123,1,,,,,,,,,,,05/07/2017,06/07/2017,,,,Thursday
+A-S00062368,,DNVdgozI30Qh47okU1c,,,,123 Fake Street,123 Fake Street,,Faketown,123 123,1,,,,,,,,,,,05/07/2017,06/07/2017,,,,Thursday
 A-S00062346,,NJvKOa0dGdiAp0uRU1c NJvKOa0dGdiAp0uRU1c,,,,test billing address line 1,,,test billing town,PE7 1LQ,1,,,,,,,,,,,05/07/2017,06/07/2017,,,,Thursday
 A-S00069777,,HQQ1rY8A1kowTKg7NDc HQQ1rY8A1kowTKg7NDc,,,,1 STREEET,,,London,A4 1AA,1,3213213213,,,,,,,,,,05/07/2017,06/07/2017,,,,Thursday
 A-S00069858,,ftwGW7hZWK78GHVXeDc ftwGW7hZWK78GHVXeDc,,,,"The Guardian Media Group, Kings Place, 90 York Way","The Guardian Media Group, Kings Place, 90 York Way",,London,N1 9GU,1,,,,,,,,burger town is the best town,,,05/07/2017,06/07/2017,,,,Thursday

--- a/src/homedelivery/export.js
+++ b/src/homedelivery/export.js
@@ -85,6 +85,15 @@ function getHolidaySuspensions (downloadStream: ReadStream): Promise<Set<string>
       .pipe(csvStream)
   })
 }
+
+function getFullName (zFirstName: string, zLastName: string) {
+  let firstName = zFirstName
+  if (firstName.trim() === '.') {
+    firstName = ''
+  }
+  return [firstName, zLastName].join(' ').trim()
+}
+
 async function processSubs (downloadStream: ReadStream, deliveryDate: moment, stage: string, holidaySuspensions: Set<string>): Promise<string> {
   let sentDate = moment().format('DD/MM/YYYY')
   let chargeDay = deliveryDate.format('dddd')
@@ -96,6 +105,7 @@ async function processSubs (downloadStream: ReadStream, deliveryDate: moment, st
   let writeCSVStream = csv.createWriteStream({
     headers: outputHeaders
   })
+
 
   let csvStream = csv.parse({
     headers: true
@@ -113,7 +123,7 @@ async function processSubs (downloadStream: ReadStream, deliveryDate: moment, st
           outputCsvRow[CUSTOMER_POSTCODE] = formatPostCode(data[POSTAL_CODE])
           outputCsvRow[CUSTOMER_ADDRESS_LINE_1] = data[ADDRESS_1]
           outputCsvRow[CUSTOMER_ADDRESS_LINE_2] = data[ADDRESS_2]
-          outputCsvRow[CUSTOMER_FULL_NAME] = [data[FIRST_NAME], data[LAST_NAME]].join(' ').trim()
+          outputCsvRow[CUSTOMER_FULL_NAME] = getFullName(data[FIRST_NAME], data[LAST_NAME])
           outputCsvRow[DELIVERY_QUANTITY] = data[QUANTITY]
           outputCsvRow[SENT_DATE] = sentDate
           outputCsvRow[DELIVERY_DATE] = formattedDeliveryDate

--- a/src/homedelivery/export.js
+++ b/src/homedelivery/export.js
@@ -106,7 +106,6 @@ async function processSubs (downloadStream: ReadStream, deliveryDate: moment, st
     headers: outputHeaders
   })
 
-
   let csvStream = csv.parse({
     headers: true
   })


### PR DESCRIPTION
looking at the latest comparator output (2017-09-14_HOME_DELIVERY.log) I realized that a couple of customers first names were blank in the salesforce fulfilment and a single dot '.' in the file generated here.

The salesforce fulfilment is just removing names that are just a dot:
https://github.com/guardian/GNMTouchpoint/blob/129e50f89458d8054eb551fa15cc56dfe0d544c6/src/classes/FulfilmentBuilderUtil.cls#L98

So this PR is just replicating this.
@AWare @paulbrown1982 