### PR TITLE
Change the weekly query and add a filter to the exporter.

### DIFF
--- a/src/weekly/export.js
+++ b/src/weekly/export.js
@@ -85,7 +85,6 @@ async function processSubs (downloadStream: ReadStream, deliveryDate: moment, st
     .on('data', (data) => {
       let subscriptionName = data[SUBSCRIPTION_NAME]
       if (holidaySuspensions.has(subscriptionName)) return
-
       exporters
       .filter(exporter => exporter.useForRow(data))
       .map(exporter => {

--- a/src/weekly/export.js
+++ b/src/weekly/export.js
@@ -84,9 +84,6 @@ async function processSubs (downloadStream: ReadStream, deliveryDate: moment, st
     })
     .on('data', (data) => {
       let subscriptionName = data[SUBSCRIPTION_NAME]
-      let changeType = data['RatePlan.AmendmentType']
-      let endDate = moment(data['RatePlanCharge.EffectiveEndDate'])
-      if (changeType === 'RemoveProduct' && deliveryDate.isSameOrAfter(endDate)) return
       if (holidaySuspensions.has(subscriptionName)) return
 
       exporters

--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -40,16 +40,15 @@ async function queryZuora (deliveryDate, config: Config) {
       Subscription.TermEndDate
         FROM
           rateplancharge
-        WHERE
-         (Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
-         ProductRatePlanCharge.ProductType__c = 'Guardian Weekly' AND
-         RatePlanCharge.EffectiveStartDate <= '${formattedDate}' AND
-         (
-          (Subscription.AutoRenew = true AND RatePlanCharge.EffectiveEndDate > '${formattedDate}') OR
-          (Subscription.AutoRenew = false AND Subscription.TermEndDate > '${formattedDate}')
-         ) AND 
-         ( RatePlan.AmendmentType != 'RemoveProduct' OR RatePlanCharge.EffectiveEndDate >= '${formattedDate}' )`
-    }
+        WHERE (Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
+        ProductRatePlanCharge.ProductType__c = 'Guardian Weekly' AND
+        RatePlanCharge.EffectiveStartDate <= '${formattedDate}' AND
+        (
+         (Subscription.AutoRenew = true AND RatePlanCharge.EffectiveEndDate > '${formattedDate}') OR
+         (Subscription.AutoRenew = false AND Subscription.TermEndDate > '${formattedDate}')
+        )   AND  (RatePlan.AmendmentType IS NULL OR RatePlan.AmendmentType != 'RemoveProduct' OR RatePlanCharge.EffectiveEndDate > '${formattedDate}' )
+    `}
+
   const holidaySuspensionQuery: Query =
     {
       'name': 'WeeklyHolidaySuspensions',

--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -47,7 +47,8 @@ async function queryZuora (deliveryDate, config: Config) {
          (
           (Subscription.AutoRenew = true AND RatePlanCharge.EffectiveEndDate > '${formattedDate}') OR
           (Subscription.AutoRenew = false AND Subscription.TermEndDate > '${formattedDate}')
-         )`
+         ) AND 
+         ( RatePlan.AmendmentType != 'RemoveProduct' OR RatePlanCharge.EffectiveEndDate >= '${formattedDate}' )`
     }
   const holidaySuspensionQuery: Query =
     {

--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -11,7 +11,6 @@ type input = {
 }
 async function queryZuora (deliveryDate, config: Config) {
   const formattedDate = deliveryDate.format('YYYY-MM-DD')
- // const deliveryDay = deliveryDate.format('dddd')
   const zuora = new Zuora(config)
   const subsQuery: Query =
     {
@@ -46,8 +45,8 @@ async function queryZuora (deliveryDate, config: Config) {
          ProductRatePlanCharge.ProductType__c = 'Guardian Weekly' AND
          RatePlanCharge.EffectiveStartDate <= '${formattedDate}' AND
          (
-          (Subscription.AutoRenew = true AND RatePlanCharge.EffectiveEndDate >= '${formattedDate}') OR
-          (Subscription.AutoRenew = false AND Subscription.TermEndDate >= '${formattedDate}')
+          (Subscription.AutoRenew = true AND RatePlanCharge.EffectiveEndDate > '${formattedDate}') OR
+          (Subscription.AutoRenew = false AND Subscription.TermEndDate > '${formattedDate}')
          )`
     }
   const holidaySuspensionQuery: Query =


### PR DESCRIPTION
This drops the number of subscription level differences from ~300 to ~100. 

This should drop when the next synchronised run of both fulfilments happens.