### PR TITLE
trigger fulfilment earlier

### DIFF
--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -304,7 +304,7 @@ Resources:
     Type: "AWS::Events::Rule"
     Properties:
       Description: "TriggerFulfilment"
-      ScheduleExpression: "cron(00 11 ? * mon-fri *)"
+      ScheduleExpression: "cron(00 9 ? * mon-fri *)"
       State: "ENABLED"
       Targets:
         -


### PR DESCRIPTION
We noticed that on Fridays the Home Delivery fulfiment file is often requested before our fulfilment lambdas run.

This would cause EDG to receive the fulfiment file generated the day before.

This PR changes the scheduling rule so that the fulfilment process runs earlier in the morning.
Expected consequences of this PR:

- EDG should always get fulfilment files generated on the same day they request it
- The comparator output for the rest of the days of the week will show more differences since there will be a couple of hours more between the generation of both files

@paulbrown1982 @johnduffell @lmath @AWare 