### PR TITLE
Hd query fix

### DIFF
--- a/src/homedelivery/query.js
+++ b/src/homedelivery/query.js
@@ -38,7 +38,7 @@ async function queryZuora (deliveryDate, config: Config) {
      RatePlanCharge.EffectiveStartDate <= '${formattedDate}' AND
      (
       ( 
-        Subscription.Status = 'Active' AND Subscription.AutoRenew = true AND RatePlanCharge.EffectiveEndDate >= '${currentDate}'
+        Subscription.Status = 'Active' AND Subscription.AutoRenew = true AND RatePlanCharge.EffectiveStartDate >= '${currentDate}' AND RatePlanCharge.EffectiveEndDate >= '${currentDate}'
       )
       OR
       (

--- a/src/homedelivery/query.js
+++ b/src/homedelivery/query.js
@@ -38,7 +38,7 @@ async function queryZuora (deliveryDate, config: Config) {
      RatePlanCharge.EffectiveStartDate <= '${formattedDate}' AND
      (
       ( 
-        Subscription.Status = 'Active' AND Subscription.AutoRenew = true AND RatePlanCharge.EffectiveStartDate >= '${currentDate}' AND RatePlanCharge.EffectiveEndDate >= '${currentDate}'
+        Subscription.Status = 'Active' AND Subscription.AutoRenew = true AND RatePlanCharge.EffectiveStartDate <= '${currentDate}' AND RatePlanCharge.EffectiveEndDate >= '${currentDate}'
       )
       OR
       (

--- a/src/homedelivery/query.js
+++ b/src/homedelivery/query.js
@@ -35,8 +35,9 @@ async function queryZuora (deliveryDate, config: Config) {
      ProductRatePlanCharge.ProductType__c = 'Print ${deliveryDay}' AND
      Product.Name = 'Newspaper Delivery' AND
      RatePlanCharge.EffectiveStartDate <= '${formattedDate}' AND
-     (Subscription.Status = 'Active' AND RatePlanCharge.EffectiveEndDate >= '${formattedDate}' OR
-      Subscription.Status = 'Cancelled' AND RatePlanCharge.EffectiveEndDate > '${formattedDate}'
+     (
+      ( Subscription.Status = 'Active' AND ( Subscription.AutoRenew = true OR RatePlanCharge.EffectiveEndDate >= '${formattedDate}' ) ) OR
+      ( Subscription.Status = 'Cancelled' AND RatePlanCharge.EffectiveEndDate > '${formattedDate} )'
      ) AND
      (RatePlanCharge.MRR != 0 OR ProductRatePlan.FrontendId__c != 'EchoLegacy')`
     } // NB to avoid case where subscription gets auto renewed after fulfilment time

--- a/src/homedelivery/query.js
+++ b/src/homedelivery/query.js
@@ -10,6 +10,7 @@ async function queryZuora (deliveryDate, config: Config) {
   const formattedDate = deliveryDate.format('YYYY-MM-DD')
   const deliveryDay = deliveryDate.format('dddd')
   const zuora = new Zuora(config)
+  const currentDate = moment().format('YYYY-MM-DD')
   const subsQuery: Query =
     {
       'name': 'Subscriptions',
@@ -27,25 +28,17 @@ async function queryZuora (deliveryDate, config: Config) {
         SoldToContact.PostalCode,
         SoldToContact.State,
         SoldToContact.workPhone,
-        SoldToContact.SpecialDeliveryInstructions__c,
-        Subscription.Version,
-        Subscription.Status,
-        RateplanCharge.Version,
-        RatePlanCharge.EffectiveEndDate,
-        RatePlan.AmendmentType,
-        RateplanCharge.Id
-        
-      FROM
+        SoldToContact.SpecialDeliveryInstructions__c
+    FROM
       rateplancharge
     WHERE
      (Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
      ProductRatePlanCharge.ProductType__c = 'Print ${deliveryDay}' AND
      Product.Name = 'Newspaper Delivery' AND
-     (RatePlan.AmendmentType IS NULL OR RatePlan.AmendmentType != 'RemoveProduct') AND
      RatePlanCharge.EffectiveStartDate <= '${formattedDate}' AND
      (
       ( 
-        Subscription.Status = 'Active' AND Subscription.AutoRenew = true AND RatePlanCharge.IsLastSegment = true
+        Subscription.Status = 'Active' AND Subscription.AutoRenew = true AND RatePlanCharge.EffectiveEndDate >= '${currentDate}'
       )
       OR
       (

--- a/src/homedelivery/query.js
+++ b/src/homedelivery/query.js
@@ -37,7 +37,7 @@ async function queryZuora (deliveryDate, config: Config) {
      RatePlanCharge.EffectiveStartDate <= '${formattedDate}' AND
      (
       ( Subscription.Status = 'Active' AND ( Subscription.AutoRenew = true OR RatePlanCharge.EffectiveEndDate >= '${formattedDate}' ) ) OR
-      ( Subscription.Status = 'Cancelled' AND RatePlanCharge.EffectiveEndDate > '${formattedDate} )'
+      ( Subscription.Status = 'Cancelled' AND RatePlanCharge.EffectiveEndDate > '${formattedDate}' )
      ) AND
      (RatePlanCharge.MRR != 0 OR ProductRatePlan.FrontendId__c != 'EchoLegacy')`
     } // NB to avoid case where subscription gets auto renewed after fulfilment time


### PR DESCRIPTION
The Home delivery query excluded subscriptions that were pending renewal since the fulfilment process executes before the renewal process.
By changing the query to include all HD subscriptions with autorenew=true we can generate the fulfilment file any number of days in advance without worrying about when the renewal takes place.

@paulbrown1982 @AWare @jacobwinch 