### PR TITLE
fix fulfilment check lambda

### DIFF
--- a/src/checker.js
+++ b/src/checker.js
@@ -1,6 +1,6 @@
 // @flow
 import moment from 'moment'
-import { getStage } from './lib/config'
+import {getStage, fetchConfig} from './lib/config'
 import { getFileInfo } from './lib/storage'
 
 export function handler (input: ?any, context: ?any, callback: Function) {
@@ -35,10 +35,10 @@ function logCheckResult (checkPassed: boolean) {
 }
 
 async function checkFile (): Promise<boolean> {
-  let stage = await getStage()
+  let config = await fetchConfig()
   let today = moment()
   let tomorrow = moment().add(1, 'day')
-  let filePath = `${stage}/fulfilment_output/${tomorrow.format('YYYY-MM-DD')}_HOME_DELIVERY.csv`
+  let filePath = `${config.fulfilments.homedelivery.uploadFolder.prefix}${tomorrow.format('YYYY-MM-DD')}_HOME_DELIVERY.csv`
   let metadata = await getFileInfo(filePath)
   let lastModified = moment(metadata.LastModified)
   console.log(`Last modified date ${lastModified.format('YYYY-MM-DD')}`)

--- a/src/checker.js
+++ b/src/checker.js
@@ -1,13 +1,14 @@
 // @flow
 import moment from 'moment'
-import {getStage, fetchConfig} from './lib/config'
+import { fetchConfig } from './lib/config'
 import { getFileInfo } from './lib/storage'
 
 export function handler (input: ?any, context: ?any, callback: Function) {
   checkFile()
     .then(checkPassed => {
       logCheckResult(checkPassed)
-      callback(null, {result: 'passed'})
+      let resultString = checkPassed ? 'passed' : 'failed'
+      callback(null, {result: resultString})
     })
     .catch(e => {
       console.log(e)

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -8,6 +8,7 @@ let s3 = new AWS.S3({signatureVersion: 'v4'})
 
 const STAGE = getStage()
 
+//TODO maybe this could be read from the config ?
 const BUCKETS = {
   CODE: 'fulfilment-export-code',
   PROD: 'fulfilment-export-prod'

--- a/src/lib/storage.js
+++ b/src/lib/storage.js
@@ -8,7 +8,7 @@ let s3 = new AWS.S3({signatureVersion: 'v4'})
 
 const STAGE = getStage()
 
-//TODO maybe this could be read from the config ?
+// TODO maybe this could be read from the config ?
 const BUCKETS = {
   CODE: 'fulfilment-export-code',
   PROD: 'fulfilment-export-prod'


### PR DESCRIPTION
We forgot to update the fulfilment checker when we changed the fulfilment buckets. This explains why the check was now consistently failing every time instead of just sometimes.
I still think we could simplify the way it works but this is a starting point

@jacobwinch 