### PR TITLE
Weekly query fix

### DIFF
--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -54,15 +54,19 @@ async function queryZuora (deliveryDate, config: Config) {
         RatePlan.Name != 'Guardian Weekly 6 Issues' AND
         RatePlan.Name != 'Guardian Weekly 12 Issues' AND
         (
-          RatePlan.AmendmentType IS NULL OR 
-            (
-             RatePlan.AmendmentType = 'RemoveProduct' AND 
-             Amendment.EffectiveDate < '${formattedDeliveryDate}' 
-             ) OR 
-            (
-             RatePlan.AmendmentType = 'NewProduct' AND 
-             Amendment.EffectiveDate >= '${formattedDeliveryDate}' 
-            )
+          RatePlan.AmendmentType IS NULL OR
+          (
+            RatePlan.AmendmentType != 'RemoveProduct' AND 
+            RatePlan.AmendmentType != 'NewProduct' 
+           ) OR
+          (
+            RatePlan.AmendmentType = 'RemoveProduct' AND 
+            Amendment.EffectiveDate > '${formattedDeliveryDate}' 
+            ) OR 
+           (
+            RatePlan.AmendmentType = 'NewProduct' AND 
+            Amendment.EffectiveDate <= '${formattedDeliveryDate}' 
+           )
         ) AND
         Subscription.ContractAcceptanceDate <= '${formattedDeliveryDate}' AND
         (
@@ -72,7 +76,7 @@ async function queryZuora (deliveryDate, config: Config) {
           ) OR
           (
             Subscription.Status = 'Cancelled' AND
-            Subscription.TermEndDate >= '${cutOffDate}'
+            Subscription.TermEndDate >= '${formattedDeliveryDate}'
           ) OR
           (
            Subscription.Status = 'Active' AND  

--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -55,7 +55,14 @@ async function queryZuora (deliveryDate, config: Config) {
         RatePlan.Name != 'Guardian Weekly 12 Issues' AND
         (
           RatePlan.AmendmentType IS NULL OR 
-          RatePlan.AmendmentType != 'RemoveProduct'
+            (
+             RatePlan.AmendmentType = 'RemoveProduct' AND 
+             Amendment.EffectiveDate < '${formattedDeliveryDate}' 
+             ) OR 
+            (
+             RatePlan.AmendmentType = 'NewProduct' AND 
+             Amendment.EffectiveDate >= '${formattedDeliveryDate}' 
+            )
         ) AND
         Subscription.ContractAcceptanceDate <= '${formattedDeliveryDate}' AND
         (

--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -76,7 +76,7 @@ async function queryZuora (deliveryDate, config: Config) {
           ) OR
           (
             Subscription.Status = 'Cancelled' AND
-            Subscription.TermEndDate >= '${formattedDeliveryDate}'
+            Subscription.TermEndDate >= '${cutOffDate}'
           ) OR
           (
            Subscription.Status = 'Active' AND  

--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -65,7 +65,7 @@ async function queryZuora (deliveryDate, config: Config) {
             ) OR 
            (
             RatePlan.AmendmentType = 'NewProduct' AND 
-            Amendment.EffectiveDate <= '${formattedDeliveryDate}' 
+            Amendment.CustomerAcceptanceDate <= '${formattedDeliveryDate}' 
            )
         ) AND
         Subscription.ContractAcceptanceDate <= '${formattedDeliveryDate}' AND


### PR DESCRIPTION
exclude rate plans that

-  are added in an amendment with acceptance date in the future 
- were removed in an amendment with effective date in the past

Note that this would fail if a rate plan is both added and removed in future amendments as it looks at only the last amendment.

@paulbrown1982 