### PR TITLE
wait a little more time for Zuora to finish the queries

### DIFF
--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -319,7 +319,7 @@ Resources:
                  "Retry": [
                     {
                      "ErrorEquals": ["States.ALL"],
-                     "IntervalSeconds": 30,
+                     "IntervalSeconds": 60,
                      "MaxAttempts": 10,
                      "BackoffRate": 1.0
                    }]


### PR DESCRIPTION
We are getting some timeouts on guardian weekly fulfilments on fridays. 
This will will make the step functions wait twice as long for Zuora queries to complete before giving up