### PR TITLE
Recognise new 6 for 6 plans

### DIFF
--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -49,7 +49,7 @@ async function queryZuora (deliveryDate, config: Config) {
         RatePlan.Name != 'Guardian Weekly 6 Issues' AND
         RatePlan.Name != 'Guardian Weekly 12 Issues' AND
         RatePlan.Name != 'GW Oct 18 - First 6 issues - ROW' AND
-        RatePlan.Name != 'GW Oct 18 - First 6 issues - Domestic' 
+        RatePlan.Name != 'GW Oct 18 - First 6 issues - Domestic' AND
         (
           RatePlan.AmendmentType IS NULL OR
           (
@@ -105,7 +105,7 @@ async function queryZuora (deliveryDate, config: Config) {
       WHERE 
        (Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
          Product.ProductType__c = 'Guardian Weekly' AND
-        ( RatePlan.Name = 'Guardian Weekly 6 Issues' OR RatePlan.Name = 'Guardian Weekly 12 Issues' OR RatePlan.Name = 'GW Oct 18 - First 6 issues - ROW' OR RatePlan.Name = 'GW Oct 18 - First 6 issues - Domestic') AND
+        ( RatePlan.Name = 'Guardian Weekly 6 Issues' OR RatePlan.Name = 'Guardian Weekly 12 Issues' OR RatePlan.Name = 'GW Oct 18 - First 6 issues - ROW' OR RatePlan.Name = 'GW Oct 18 - First 6 issues - Domestic' ) AND
         ( RatePlan.AmendmentType IS NULL OR RatePlan.AmendmentType != 'RemoveProduct' ) AND
         RatePlanCharge.EffectiveStartDate <= '${formattedDeliveryDate}' AND
         RatePlanCharge.EffectiveEndDate > '${formattedDeliveryDate}' 

--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -48,8 +48,8 @@ async function queryZuora (deliveryDate, config: Config) {
         Product.ProductType__c = 'Guardian Weekly' AND
         RatePlan.Name != 'Guardian Weekly 6 Issues' AND
         RatePlan.Name != 'Guardian Weekly 12 Issues' AND
-        RatePlan.Name != 'GW Oct 18 - First 6 issues - ROW' AND
-        RatePlan.Name != 'GW Oct 18 - First 6 issues - Domestic' AND
+        RatePlan.Name != 'GW Oct 18 - Six for Six - ROW' AND
+        RatePlan.Name != 'GW Oct 18 - Six for Six - Domestic' AND
         (
           RatePlan.AmendmentType IS NULL OR
           (
@@ -105,7 +105,7 @@ async function queryZuora (deliveryDate, config: Config) {
       WHERE 
        (Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
          Product.ProductType__c = 'Guardian Weekly' AND
-        ( RatePlan.Name = 'Guardian Weekly 6 Issues' OR RatePlan.Name = 'Guardian Weekly 12 Issues' OR RatePlan.Name = 'GW Oct 18 - First 6 issues - ROW' OR RatePlan.Name = 'GW Oct 18 - First 6 issues - Domestic' ) AND
+        ( RatePlan.Name = 'Guardian Weekly 6 Issues' OR RatePlan.Name = 'Guardian Weekly 12 Issues' OR RatePlan.Name = 'GW Oct 18 - Six for Six - ROW' OR RatePlan.Name = 'GW Oct 18 - Six for Six - Domestic' ) AND
         ( RatePlan.AmendmentType IS NULL OR RatePlan.AmendmentType != 'RemoveProduct' ) AND
         RatePlanCharge.EffectiveStartDate <= '${formattedDeliveryDate}' AND
         RatePlanCharge.EffectiveEndDate > '${formattedDeliveryDate}' 

--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -48,6 +48,8 @@ async function queryZuora (deliveryDate, config: Config) {
         Product.ProductType__c = 'Guardian Weekly' AND
         RatePlan.Name != 'Guardian Weekly 6 Issues' AND
         RatePlan.Name != 'Guardian Weekly 12 Issues' AND
+        RatePlan.Name != 'GW Oct 18 - First 6 issues - ROW' AND
+        RatePlan.Name != 'GW Oct 18 - First 6 issues - Domestic' 
         (
           RatePlan.AmendmentType IS NULL OR
           (
@@ -103,7 +105,7 @@ async function queryZuora (deliveryDate, config: Config) {
       WHERE 
        (Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
          Product.ProductType__c = 'Guardian Weekly' AND
-        ( RatePlan.Name = 'Guardian Weekly 6 Issues' OR RatePlan.Name = 'Guardian Weekly 12 Issues' ) AND
+        ( RatePlan.Name = 'Guardian Weekly 6 Issues' OR RatePlan.Name = 'Guardian Weekly 12 Issues' OR RatePlan.Name = 'GW Oct 18 - First 6 issues - ROW' OR RatePlan.Name = 'GW Oct 18 - First 6 issues - Domestic') AND
         ( RatePlan.AmendmentType IS NULL OR RatePlan.AmendmentType != 'RemoveProduct' ) AND
         RatePlanCharge.EffectiveStartDate <= '${formattedDeliveryDate}' AND
         RatePlanCharge.EffectiveEndDate > '${formattedDeliveryDate}' 


### PR DESCRIPTION
The new GW products use different rate plan names for introductory periods (e.g. 6 for 6), so they aren't being picked up correctly by our queries.