### PR TITLE
Extend polling period for FetchResults lambda

### DIFF
--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -303,7 +303,7 @@ Resources:
                     {
                      "ErrorEquals": ["States.ALL"],
                      "IntervalSeconds": 60,
-                     "MaxAttempts": 10,
+                     "MaxAttempts": 20,
                      "BackoffRate": 1.0
                    }]
                },


### PR DESCRIPTION
This has been timing out recently. When I re-ran an execution the queries completed relatively soon after we gave up polling.

I don't think there's any harm in increasing the number of retries here.