### PR TITLE
Use holiday start date as threshold for GW fulfilment suspension

### DIFF
--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -123,7 +123,7 @@ async function queryZuora (deliveryDate, config: Config) {
        (Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
        ProductRatePlanCharge.ProductType__c = 'Adjustment' AND
        RateplanCharge.Name = 'Holiday Credit' AND
-       RatePlanCharge.EffectiveStartDate <= '${formattedDeliveryDate}' AND
+       RatePlanCharge.HolidayStart__c <= '${formattedDeliveryDate}' AND
        RatePlanCharge.HolidayEnd__c >= '${formattedDeliveryDate}' AND
        RatePlan.AmendmentType != 'RemoveProduct'`
     }


### PR DESCRIPTION
Our new way of amending subscriptions for holiday stops makes the effective date of the holiday stop (when the credit is paid) the first day of the next billing period.  This means that the current query to find publications that shouldn't be delivered won't work; it uses the effective date as the threshold for finding holiday stops but obviously that will always be false in the future with the new method.

I think the logic of this should continue to work with existing manually applied stops.  Please let me know if this isn't true.  I've run a report on prod data and there are differences between the two data sets but only where it looks like a subscription is being included iin the current dataset when it shouldn't be there.

What I don't understand is why this query isn't filtered on GW products only.
