### PR TITLE
logging of input and Zuora jobId

### DIFF
--- a/src/homedelivery/query.js
+++ b/src/homedelivery/query.js
@@ -95,5 +95,6 @@ export async function homedeliveryQuery (input: input) {
   let deliveryDate = getDeliveryDate(input)
   let config = await fetchConfig()
   console.log('Config fetched succesfully.')
+  console.log('Input: ', input)
   return queryZuora(deliveryDate, config)
 }

--- a/src/lib/Zuora.js
+++ b/src/lib/Zuora.js
@@ -64,6 +64,7 @@ export class Zuora {
           console.log(`zuora error! code: ${body.errorCode} : ${body.message}`)
           reject(new NamedError('api_call_error', `zuora error! code: ${body.errorCode} : ${body.message}`))
         } else {
+          console.log('jobId: ', body.id)
           resolve(body.id)
         }
       })


### PR DESCRIPTION
As part of https://trello.com/c/4XuwmRVh/563-goal-add-delivery-schedule-for-everyday-rate-plan-subscriptions, I spent a lot of time digging around the Zuora UI and doing painful stuff like inspecting the HTML to retrieve the Zuora Job Id. 

Hence this change to make it easier to get hold of the Job Id by printing it to console. This should allow others in the future to simply look through the Cloudwatch logs and pull out the Zuora Job Id. I am also outputting the input, to make it easier to identify which data and type of jobs is running.

Sample output when run locally.

```
Input:  { deliveryDate: '2017-09-01', type: 'homedelivery' }
statusCode: 200
jobId:  2c92c0f86e20d827016e222f9e2d1d26
```