### PR TITLE
Handle Home Delivery holiday stops not based on EffectiveStartDate

### DIFF
--- a/src/homedelivery/query.js
+++ b/src/homedelivery/query.js
@@ -53,7 +53,7 @@ async function queryZuora (deliveryDate, config: Config) {
      (RatePlanCharge.MRR != 0 OR ProductRatePlan.FrontendId__c != 'EchoLegacy')`
     } // NB to avoid case where subscription gets auto renewed after fulfilment time
 
-  /* FIXME: After migration remove the second OR disjunct in the where clause */
+  /* FIXME: The second OR disjunct can be removed once HolidayEnd__c of the last old style holiday stop has passed */
   const holidaySuspensionQuery: Query =
     {
       name: 'HolidaySuspensions',
@@ -68,10 +68,9 @@ async function queryZuora (deliveryDate, config: Config) {
        RateplanCharge.Name = 'Holiday Credit' AND
        RatePlanCharge.HolidayStart__c <= '${formattedDate}' AND
        RatePlanCharge.HolidayEnd__c >= '${formattedDate}' AND
-       RatePlan.AmendmentType != 'RemoveProduct')
-       
+       RatePlan.AmendmentType != 'RemoveProduct' AND
+       RatePlan.Name = 'DO NOT USE MANUALLY: Holiday Credit - automated')
        OR
-
        ((Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
        ProductRatePlanCharge.ProductType__c = 'Adjustment' AND
        RateplanCharge.Name = 'Holiday Credit' AND


### PR DESCRIPTION
**FIXME**: The second OR disjunct can be removed once `HolidayEnd__c` of the last old style holiday stop has passed:

```
       ((Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
       ProductRatePlanCharge.ProductType__c = 'Adjustment' AND
       RateplanCharge.Name = 'Holiday Credit' AND
       RatePlanCharge.EffectiveStartDate <= '${formattedDate}' AND
       RatePlanCharge.HolidayEnd__c >= '${formattedDate}' AND
       RatePlan.AmendmentType != 'RemoveProduct')
```

In the new world `EffectiveStartDate` indicates when the credit will be applied in the next invoice, **not** the holiday stop date.



Related Guardian Weekly PR: https://github.com/guardian/fulfilment-lambdas/pull/112
