### PR TITLE
Update RatePlan.Name filter of Home Delivery holiday suspensions

### DIFF
--- a/src/homedelivery/query.js
+++ b/src/homedelivery/query.js
@@ -69,7 +69,7 @@ async function queryZuora (deliveryDate, config: Config) {
        RatePlanCharge.HolidayStart__c <= '${formattedDate}' AND
        RatePlanCharge.HolidayEnd__c >= '${formattedDate}' AND
        RatePlan.AmendmentType != 'RemoveProduct' AND
-       RatePlan.Name = 'DO NOT USE MANUALLY: Holiday Credit - automated')
+       RatePlan.Name LIKE 'DO NOT USE MANUALLY: Holiday Credit - automated%')
        OR
        ((Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
        ProductRatePlanCharge.ProductType__c = 'Adjustment' AND


### PR DESCRIPTION
## What does this change?

Related PR: https://github.com/guardian/support-service-lambdas/pull/686

Zuora now has per-product holiday credit rate plans

![image](https://user-images.githubusercontent.com/13835317/94065875-9bb5ae00-fde3-11ea-9c33-f323d9fbe70e.png)

whilst previously there was only one for all

```
DO NOT USE MANUALLY: Holiday credit - automated
```

which was hardcoded in the filter.

## How to test

Query can be tested directly in postman, for example

```
POST /v1/batch-query/ HTTP/1.1
Host: rest.zuora.com
Accept: application/json
Content-Type: application/json
Authorization: Bearer ***************

{
	"format" : "csv",
	"version" : "1.0",
	"name" : "mario-fulfilment_lambda_holidaysuspension-hd",
	"encrypted" : "none",
	"useQueryLabels" : "true",
	"dateTimeUtc" : "true",
	"queries" : [
		{
			"name" : "mario-fulfilment_lambda_holidaysuspension",
			"query" : "SELECT Subscription.Name FROM rateplancharge WHERE ((Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND ProductRatePlanCharge.ProductType__c = 'Adjustment' AND RateplanCharge.Name = 'Holiday Credit' AND RatePlanCharge.HolidayStart__c <= '2020-09-19' AND RatePlanCharge.HolidayEnd__c >= '2020-09-19' AND RatePlan.AmendmentType != 'RemoveProduct' AND RatePlan.Name LIKE 'DO NOT USE MANUALLY: Holiday Credit - automated%') OR ((Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND ProductRatePlanCharge.ProductType__c = 'Adjustment' AND RateplanCharge.Name = 'Holiday Credit' AND RatePlanCharge.EffectiveStartDate <= '2020-09-19' AND RatePlanCharge.HolidayEnd__c >= '2020-09-19' AND RatePlan.AmendmentType != 'RemoveProduct')",
			"type" : "zoqlexport"
		}
	]
}
```

After deploying run the step function as documented [here](https://github.com/guardian/fulfilment-lambdas#validating-deployment-to-prod) and then check `fulfilment-export-prod/zuoraExport/HolidaySuspensions_*` files. Pick a subscription from the file and then check in Salesforce if there is a corresponding HRS with that Stopped Publication Date. For example, `HolidaySuspensions_2020-09-19_*.csv` should have corresponding HRS with 2020-09-19 Stopped Publication Date.

## How can we measure success?



`HolidaySuspensions_*` files should no longer be empty

![image](https://user-images.githubusercontent.com/13835317/94067302-92c5dc00-fde5-11ea-96b0-b602a2a66508.png)


## Have we considered potential risks?

- Before re-running step functions, make backup of fulfilment file proper to diff it with same file after 
- Double check the filtered out subscriptions are indeed the ones with holiday stops
- For example `fulfilment-export-prod/fulfilment_output/2020-09-24_HOME_DELIVERY.csv` should be a bit smaller and have only subs with holiday stops removed.

