### PR TITLE
Simplify home-delivery holiday-stop query

### DIFF
--- a/src/homedelivery/query.js
+++ b/src/homedelivery/query.js
@@ -53,7 +53,6 @@ async function queryZuora (deliveryDate, config: Config) {
      (RatePlanCharge.MRR != 0 OR ProductRatePlan.FrontendId__c != 'EchoLegacy')`
     } // NB to avoid case where subscription gets auto renewed after fulfilment time
 
-  /* FIXME: The second OR disjunct can be removed once HolidayEnd__c of the last old style holiday stop has passed */
   const holidaySuspensionQuery: Query =
     {
       name: 'HolidaySuspensions',
@@ -63,21 +62,12 @@ async function queryZuora (deliveryDate, config: Config) {
       FROM
         rateplancharge
       WHERE
-       ((Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
+       (Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
        ProductRatePlanCharge.ProductType__c = 'Adjustment' AND
        RateplanCharge.Name = 'Holiday Credit' AND
        RatePlanCharge.HolidayStart__c <= '${formattedDate}' AND
        RatePlanCharge.HolidayEnd__c >= '${formattedDate}' AND
-       RatePlan.AmendmentType != 'RemoveProduct' AND
-       RatePlan.Name LIKE 'DO NOT USE MANUALLY: Holiday Credit - automated%')
-       OR
-       ((Subscription.Status = 'Active' OR Subscription.Status = 'Cancelled') AND
-       ProductRatePlanCharge.ProductType__c = 'Adjustment' AND
-       RateplanCharge.Name = 'Holiday Credit' AND
-       RatePlanCharge.EffectiveStartDate <= '${formattedDate}' AND
-       RatePlanCharge.HolidayEnd__c >= '${formattedDate}' AND
-       RatePlan.AmendmentType != 'RemoveProduct')
-     `
+       RatePlan.AmendmentType != 'RemoveProduct'     `
     }
   const jobId = await zuora.query('Fulfilment-Queries', subsQuery, holidaySuspensionQuery)
   return { deliveryDate: formattedDate, jobId: jobId }


### PR DESCRIPTION
## What does this change?
Previously, the home-delivery holiday-stop query unnecessarily referred to discount rate plans by name.  This change removes that dependency.  It also removes an old query that is now redundant.  As a result the home-delivery query is identical to the GW query.  So a further step could be to share them.

## How to test
1. I've set up reports for the query as it was and compared the results with an identical query without the discount rate-plan name.  The results for both are identical.
1. I've run a report for the old query to prove that it's now redundant as it has no results.

## How can we measure success?
We should check a few holiday-stop files after this is merged to ensure there are still contents.

## Have we considered potential risks?
The change might stop holiday-stops being output and so they will be delivered in spite of the stop.  I propose to merge this next week so that there's time to find any problems and rollback if necessary.

## Images
N/A.
