### PR TITLE
Format delivery instructions for Salesforce CSV parser

### DIFF
--- a/__tests__/lib/formatters.js
+++ b/__tests__/lib/formatters.js
@@ -1,0 +1,8 @@
+/* eslint-env jest */
+import { formatDeliveryInstructions } from '../../src/lib/formatters'
+
+test('should format delivery instructions for Salesforce CSV parser', () => {
+  const deliveryInstructions = 'front door is on ""Foo\'s Drive "",Put though the letterbox, do not leave on door step.'
+  const expected = 'front door is on \'Foo\'s Drive \',Put though the letterbox, do not leave on door step.'
+  expect(formatDeliveryInstructions(deliveryInstructions)).toEqual(expected)
+})

--- a/src/homedelivery/export.js
+++ b/src/homedelivery/export.js
@@ -1,7 +1,7 @@
 // @flow
 import * as csv from 'fast-csv'
 import moment from 'moment'
-import { formatPostCode } from './../lib/formatters'
+import { formatPostCode, formatDeliveryInstructions } from './../lib/formatters'
 import { upload, createReadStream } from './../lib/storage'
 import { ReadStream } from 'fs'
 import { getStage, fetchConfig } from './../lib/config'
@@ -125,7 +125,7 @@ async function processSubs (downloadStream: ReadStream, deliveryDate: moment, st
       outputCsvRow[DELIVERY_DATE] = formattedDeliveryDate
       outputCsvRow[CHARGE_DAY] = chargeDay
       outputCsvRow[CUSTOMER_PHONE] = row[WORK_PHONE]
-      outputCsvRow[ADDITIONAL_INFORMATION] = row[DELIVERY_INSTRUCTIONS]
+      outputCsvRow[ADDITIONAL_INFORMATION] = formatDeliveryInstructions(row[DELIVERY_INSTRUCTIONS])
       csvStream.write(outputCsvRow)
     }
   }

--- a/src/lib/formatters.js
+++ b/src/lib/formatters.js
@@ -10,3 +10,18 @@ export function formatPostCode (postCode: string) {
   const inward = normalised.substring(length - 3)
   return `${outward} ${inward}`
 }
+
+/**
+ * Replace double quotes " with single quotes ' because Salesforce CSV parser gets confused if it sees
+ * double quites followed by a comma "", within the column value itself, for example:
+ *
+ * BEFORE:
+ *  "front door is on ""Foo's Drive "",Put though the letterbox, do not leave on door step."
+ *
+ * AFTER:
+ *  "front door is on 'Foo's Drive ',Put though the letterbox, do not leave on door step."
+ *
+ */
+export function formatDeliveryInstructions (deliveryInstructions: string) {
+  return deliveryInstructions.replace(/""/g, '\'')
+}


### PR DESCRIPTION
## What does this change?

* Addresses email `CSR bug report - case: 01710356`
* Salesforce [CSVReader.cls ](https://github.com/guardian/salesforce/blob/1841a6c6a64b638afef2916ca0b643dbbb7d8a6f/force-app/main/default/classes/CsvReader.cls) seems to get confused if a column value has double quotes followed by comma inside it `"",`
* Related PR: https://github.com/guardian/salesforce/pull/328

## How to test

Unit test

```
yarn jest -t='should format delivery instructions for Salesforce CSV parser'
```

Check in Salesforce

```
SELECT id, Class_Name__c, CreatedDate, info__c 
FROM Apex_Error__c
WHERE Class_Name__c='DeliveryDocumentWrapper'
ORDER BY CreatedDate DESC
LIMIT 5
```

and subscription a2F0J000002jK6z.

## How can we measure success?

Delivery records for a2F0J000002jK6z should be correctly populated including delivery address and delivery instructions.

## Have we considered potential risks?

* Replacing double quotes with single quotes should not change the meaning of delivery instructions.
* Note we are only replacing double double quotes, that is, `""` not `"`.
