### PR TITLE
Replace all double quotes with single quotes in delivery instructions column

### DIFF
--- a/__tests__/lib/formatters.js
+++ b/__tests__/lib/formatters.js
@@ -8,7 +8,7 @@ import la from 'lodash/array'
 
 test('should format delivery instructions for Salesforce CSV parser', () => {
   const deliveryInstructions = 'front door is on ""Foo\'s Drive "",Put though the letterbox, do not leave on door step.'
-  const expected = 'front door is on \'Foo\'s Drive \',Put though the letterbox, do not leave on door step.'
+  const expected = 'front door is on \'\'Foo\'s Drive \'\',Put though the letterbox, do not leave on door step.'
   expect(formatDeliveryInstructions(deliveryInstructions)).toEqual(expected)
 })
 

--- a/__tests__/lib/formatters.js
+++ b/__tests__/lib/formatters.js
@@ -7,9 +7,9 @@ import { outputHeaders as hdOutputHeaders } from '../../src/homedelivery/export'
 import la from 'lodash/array'
 
 test('should format delivery instructions for Salesforce CSV parser', () => {
-  const deliveryInstructions = 'front door is on ""Foo\'s Drive "",Put though the letterbox, do not leave on door step.'
-  const expected = 'front door is on \'\'Foo\'s Drive \'\',Put though the letterbox, do not leave on door step.'
-  expect(formatDeliveryInstructions(deliveryInstructions)).toEqual(expected)
+  const rawSpecialDeliveryInstructionsInSoldToZuoraContact = 'front door is on "Foo\'s Drive ",Put though the letterbox, do not leave on door step.'
+  const expected = 'front door is on \'Foo\'s Drive \',Put though the letterbox, do not leave on door step.'
+  expect(formatDeliveryInstructions(rawSpecialDeliveryInstructionsInSoldToZuoraContact)).toEqual(expected)
 })
 
 test('output format for Salesforce CSV parser', async () => {

--- a/src/lib/formatters.js
+++ b/src/lib/formatters.js
@@ -19,16 +19,20 @@ export function formatPostCode (postCode: string) {
 }
 
 /**
+ * Needed because Salesforce CsvReader bug:
+ *   Clarify with tests current behaviour of CsvReader regarding quotes and commas #333
+ *   https://github.com/guardian/salesforce/pull/333
+ *
  * Replace double quotes " with single quotes ' because Salesforce CSV parser gets confused if it sees
- * double quites followed by a comma "", within the column value itself, for example:
+ * double quotes followed by a comma ", within the column value itself, for example:
  *
  * BEFORE:
- *  "front door is on ""Foo's Drive "",Put though the letterbox, do not leave on door step."
+ *  "front door is on "Foo's Drive ",Put though the letterbox, do not leave on door step."
  *
  * AFTER:
  *  "front door is on 'Foo's Drive ',Put though the letterbox, do not leave on door step."
  *
  */
 export function formatDeliveryInstructions (deliveryInstructions: string) {
-  return deliveryInstructions.replace(/""/g, '\'')
+  return deliveryInstructions.replace(/"/g, '\'')
 }


### PR DESCRIPTION
## What does this change?

* Workaround for limitation in Salesforce CsvReader: [Clarify with tests current behaviour of CsvReader regarding quotes and commas #333](https://github.com/guardian/salesforce/pull/333)
* 

## How to test

1. Added `",` combination in `Sold To` contact 

    ![image](https://user-images.githubusercontent.com/13835317/105849311-1b44cb00-5fd8-11eb-9bd6-d9bd52883c73.png)

1. Execute CODE fulfilment step function

1. Compare CSV files before and after

    ![image](https://user-images.githubusercontent.com/13835317/105849101-d6b92f80-5fd7-11eb-951d-7e28c37b636e.png)


## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

- Currently we apply this transformation only on delivery instructions field. Theoretically this could happen on any field but it is unlikely. If it happens again on another field, we could look into expanding transformation across fields or indeed modifying Salesforce CSV parsers to handle `",` sequence within particular field.
- Note fast-csv also has out-of-the-box facility to transform rows https://c2fo.github.io/fast-csv/docs/formatting/examples#transforming-rows
