### PR TITLE
Rewire Hong Kong (HK) subscribers to Rest of the World (ROW) fulfilment file

### DIFF
--- a/__tests__/weekly/exporter.js
+++ b/__tests__/weekly/exporter.js
@@ -232,6 +232,6 @@ it('should generate correct fulfilment file for weekly', async () => {
     ]
   }
 
-  const expectedResponse = { ...input, fulfilmentFile: '2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv' }
+  const expectedResponse = { ...input, fulfilmentFile: '2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv,2017-07-06_WEEKLY.csv' }
   await expect(handler(input, {})).resolves.toEqual(expectedResponse)
 })

--- a/src/weekly/export.js
+++ b/src/weekly/export.js
@@ -87,7 +87,6 @@ async function processSubs (downloadStream: ReadStream, deliveryDate: moment, st
     new UpperCaseAddressExporter('Australia', deliveryDate, config.fulfilments.weekly.AU.uploadFolder),
     new WeeklyExporter('France', deliveryDate, config.fulfilments.weekly.FR.uploadFolder),
     new UpperCaseAddressExporter('New Zealand', deliveryDate, config.fulfilments.weekly.NZ.uploadFolder),
-    new WeeklyExporter('Hong Kong', deliveryDate, config.fulfilments.weekly.ROW.uploadFolder),
     new UpperCaseAddressExporter('Vanuatu', deliveryDate, config.fulfilments.weekly.VU.uploadFolder),
     rowExporter
   ]

--- a/src/weekly/export.js
+++ b/src/weekly/export.js
@@ -87,7 +87,7 @@ async function processSubs (downloadStream: ReadStream, deliveryDate: moment, st
     new UpperCaseAddressExporter('Australia', deliveryDate, config.fulfilments.weekly.AU.uploadFolder),
     new WeeklyExporter('France', deliveryDate, config.fulfilments.weekly.FR.uploadFolder),
     new UpperCaseAddressExporter('New Zealand', deliveryDate, config.fulfilments.weekly.NZ.uploadFolder),
-    new WeeklyExporter('Hong Kong', deliveryDate, config.fulfilments.weekly.HK.uploadFolder),
+    new WeeklyExporter('Hong Kong', deliveryDate, config.fulfilments.weekly.ROW.uploadFolder),
     new UpperCaseAddressExporter('Vanuatu', deliveryDate, config.fulfilments.weekly.VU.uploadFolder),
     rowExporter
   ]

--- a/src/weekly/export.js
+++ b/src/weekly/export.js
@@ -66,6 +66,7 @@ function getHolidaySuspensions (downloadStream: ReadStream): Promise<Set<string>
 
 /**
  * Transfroms raw CSV from Zuora to expected CSV format, splits it per regions, and uploads it to S3 fulfilments folder.
+ * If an exporter is not defined for a specific country, then it defaults to Rest of the world (ROW) fulfilment file.
  * FIXME: Rename fulfilments to something meaningful such as guardian_weekly!
  *
  * @param downloadStream raw Guardian Weekly CSV exported from Zuora


### PR DESCRIPTION
## What does this change?

* https://trello.com/c/IGKv1DCf/2046-missing-hong-kong-fulfilment
* It seems old HK fulfilment provider is no longer valid, and we need to switch to the one serving ROW
* In terms of implementation change, if an explicit country is not specified, then it defaults to ROW. 

## How to test

* https://github.com/guardian/fulfilment-lambdas#validating-deployment-to-prod
* Tested both in CODE and PROD (with temporarily released branch) by comparing files before and after. The HK rows are now added to ROW file `fulfilments/Weekly_ROW/2021-02-19_WEEKLY.csv` and the existing records do not seem to be affected.

## How can we measure success?

Successful fulfilment to HK subscribers.

## Have we considered potential risks?

* The change seems to affect only GW
* The change seems to affect only ROW file
* ROW file does not seem corrupt and has more records than before due to added HK records. 

