### PR TITLE
Do not upload HK fulfilment file to salesforce

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -42,7 +42,6 @@ export type Config = {
       NZ: uploadDownload,
       FR: uploadDownload,
       VU: uploadDownload,
-      HK: uploadDownload,
       AU: uploadDownload,
       UK: uploadDownload,
       CA: uploadDownload,

--- a/src/weekly/salesforce_uploader.js
+++ b/src/weekly/salesforce_uploader.js
@@ -45,7 +45,6 @@ export async function handler (input: WeeklyInput) {
     buildSourceAndDestination(config.fulfilments.weekly.AU, s3ToSfName('GWAU'), sourceFileName),
     buildSourceAndDestination(config.fulfilments.weekly.CA, s3ToSfName('GWCA'), sourceFileName),
     buildSourceAndDestination(config.fulfilments.weekly.CAHAND, s3ToSfName('GWCA_HAND'), sourceFileName),
-    buildSourceAndDestination(config.fulfilments.weekly.HK, s3ToSfName('GWHK'), sourceFileName),
     buildSourceAndDestination(config.fulfilments.weekly.ROW, s3ToSfName('GWRW'), sourceFileName),
     buildSourceAndDestination(config.fulfilments.weekly.UK, s3ToSfName('GWUK'), sourceFileName),
     buildSourceAndDestination(config.fulfilments.weekly.US, s3ToSfName('GWUS'), sourceFileName),


### PR DESCRIPTION
## What does this change?

* Related PR: https://github.com/guardian/fulfilment-lambdas/pull/153
* Since HK now goes to ROW, there will be nothing to upload to salesforce.

## How to test

Run `weekly-fulfilmentUploader-CODE` lambda and check HK is not part of the output

```
[
  {
    "name": "GWNZ_19_02_2021_10022021_16.csv",
    "id": ""
  },
  {
    "name": "GWFR_19_02_2021_10022021_16.csv",
    "id": ""
  },
  {
    "name": "GWAU_19_02_2021_10022021_16.csv",
    "id": ""
  },
  {
    "name": "GWCA_19_02_2021_10022021_16.csv",
    "id": ""
  },
  {
    "name": "GWCA_HAND_19_02_2021_10022021_16.csv",
    "id": ""
  },
  {
    "name": "GWRW_19_02_2021_10022021_16.csv",
    "id": ""
  },
  {
    "name": "GWUK_19_02_2021_10022021_16.csv",
    "id": ""
  },
  {
    "name": "GWUS_19_02_2021_10022021_16.csv",
    "id": ""
  },
  {
    "name": "GWVA_19_02_2021_10022021_16.csv",
    "id": ""
  }
]
```

## How can we measure success?


## Have we considered potential risks?

* There should be no risk given HK files have not been used by the provider for fulfilment anyways.
