### PR TITLE
Fix erroneous duplicate copies of Guardian Weekly in fulfilment files

### DIFF
--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -43,7 +43,7 @@ async function queryZuora (deliveryDate, config: Config) {
       SoldToContact.State,
       Subscription.CanadaHandDelivery__c
       FROM
-        rateplan
+        RatePlanCharge
       WHERE 
         Product.ProductType__c = 'Guardian Weekly' AND
         RatePlan.Name != 'Guardian Weekly 6 Issues' AND
@@ -58,13 +58,15 @@ async function queryZuora (deliveryDate, config: Config) {
            ) OR
           (
             RatePlan.AmendmentType = 'RemoveProduct' AND 
-            Amendment.EffectiveDate > '${formattedDeliveryDate}' 
+            Amendment.EffectiveDate > '${formattedDeliveryDate}' AND
+            EffectiveStartDate <= '${formattedDeliveryDate}' 
             ) OR 
            (
             RatePlan.AmendmentType = 'NewProduct' AND 
             Amendment.CustomerAcceptanceDate <= '${formattedDeliveryDate}' 
            )
         ) AND
+        IsLastSegment = true AND
         Subscription.ContractAcceptanceDate <= '${formattedDeliveryDate}' AND
         (
           (


### PR DESCRIPTION
## What does this change?

https://trello.com/c/93cyav3B/2037-erroneous-duplicates-in-fulfilment-files

The cause of the problem is adding (and removing) multiple subsequent products in advance, that is having the following sequence of amendments: 

```
Remove Product -> Add Product -> Renew -> Remove Product -> Add Product -> Renew -> ...
```

which results in multiple `Amendment.EffectiveDate` being satisfied by filter

```
Amendment.EffectiveDate > '${formattedDeliveryDate}'
``` 

due to 

| Subscription  | AmendmentType  | Amendment.EffectiveDate  | EffectiveStartDate |
| ------------- | ------------------ |  -------------------------- | ------------------ |
| A00000         | RemoveProduct     | 2021-03-29                         | 2020-03-29          |
| A00000         | RemoveProduct      | 2022-03-29                        | 2021-03-29          |
| ...                   | ...                             | ...                                           | ...                            |

This may happen if the CSR emulates say a 3-year GW product, which does not actually exists, by scheduled three consecutive GW Oct 18 - 1 Year - Domestic:


![image](https://user-images.githubusercontent.com/13835317/108535715-87fb6e80-72d3-11eb-903e-6233128b9a15.png)




The fix is to tighten the filter by switching from `RatePlan` to `RatePlanCharge` which gives use 

```
RatePlanCharge. EffectiveStartDate
``` 

which we can use to eliminate amendments that are too far in the future. 

Note `IsLastSegment = true` is necessary because otherwise multiple `RatePlanCharge`s could be returned.    

## How to test

1. Use Postman to get before and after exports
2. I've added temporarily extra fields to check the dates of duplicates
 
```
        Subscription.ContractAcceptanceDate,
        RatePlan.AmendmentType,
        Amendment.EffectiveDate,
        Amendment.CustomerAcceptanceDate,
        Amendment.TermStartDate,
        EffectiveStartDate,
        EffectiveEndDate,
        version,
        Id,
        RatePlan.Id,
        Subscription.Status
```
3. `sort before.csv | guniq -cd`
4. `sort after.csv | guinq -cd`
5. Diff with IntelliJ and analyse every single difference
6. `wc -l` before and after

## How can we measure success?

Using the above test procedure monitor for extended period of time if erroneous duplicates have stopped whilst valid ones (such as for library) continue unchanged.

## Have we considered potential risks?

Verification of query change from RatePlan to RatePlanCharge has been done in two stages. First I made sure that switching produces exact same results (including duplicates) as the old RatePlan-based query

```
SELECT
        Subscription.Name,
        SoldToContact.Address1,
        SoldToContact.Address2,
        SoldToContact.City,
        SoldToContact.Company_Name__c,
        SoldToContact.Country,
        SoldToContact.Title__c,
        SoldToContact.FirstName,
        SoldToContact.LastName,
        SoldToContact.PostalCode,
        SoldToContact.State,
        Subscription.CanadaHandDelivery__c
        Subscription.ContractAcceptanceDate,
        RatePlan.AmendmentType,
        Amendment.EffectiveDate,
        Amendment.CustomerAcceptanceDate,
        Amendment.TermStartDate,
        EffectiveStartDate,
        EffectiveEndDate,
        version,
        Id,
        RatePlan.Id,
        Subscription.Status  
    FROM
        RatePlanCharge 
    WHERE
        Product.ProductType__c = 'Guardian Weekly' 
        AND RatePlan.Name != 'Guardian Weekly 6 Issues' 
        AND RatePlan.Name != 'Guardian Weekly 12 Issues' 
        AND RatePlan.Name != 'GW Oct 18 - Six for Six - ROW' 
        AND RatePlan.Name != 'GW Oct 18 - Six for Six - Domestic' 
        AND (
            RatePlan.AmendmentType IS NULL 
            OR (
                RatePlan.AmendmentType != 'RemoveProduct' 
                AND RatePlan.AmendmentType != 'NewProduct'
            ) 
            OR (
                RatePlan.AmendmentType = 'RemoveProduct' 
                AND (
                    Amendment.EffectiveDate > '2021-02-26'
                )
            ) 
            OR (
                RatePlan.AmendmentType = 'NewProduct' 
                AND Amendment.CustomerAcceptanceDate <= '2021-02-26'
            )
        ) 
        AND Subscription.ContractAcceptanceDate <= '2021-02-26' 
        AND IsLastSegment = true 
        AND (
            (
                Subscription.AutoRenew = true 
                AND Subscription.Status = 'Active'
            ) 
            OR (
                Subscription.Status = 'Cancelled' 
                AND Subscription.TermEndDate >= '2021-02-13'
            ) 
            OR (
                Subscription.Status = 'Active' 
                AND Subscription.AutoRenew = false 
                AND Subscription.TermEndDate >= '2021-02-13'
            )
        )

```

After that I added the extra `EffectiveStartDate <= '${formattedDeliveryDate}' ` to tighten the filter. Then I diffed the before and after exports and analysed each difference to see if it makes sense.  
