### PR TITLE
Removing the phone number from the Home Delivery fulfilment file

### DIFF
--- a/src/homedelivery/export.js
+++ b/src/homedelivery/export.js
@@ -153,7 +153,7 @@ async function processSubs (downloadStream: ReadStream, deliveryDate: moment, st
       outputCsvRow[SENT_DATE] = sentDate
       outputCsvRow[DELIVERY_DATE] = formattedDeliveryDate
       outputCsvRow[CHARGE_DAY] = chargeDay
-      outputCsvRow[CUSTOMER_PHONE] = row[WORK_PHONE]
+      outputCsvRow[CUSTOMER_PHONE] = '' // row[WORK_PHONE] - Removed on 6 April 2021 due to no longer being necessary.
       outputCsvRow[ADDITIONAL_INFORMATION] = formatDeliveryInstructions(row[DELIVERY_INSTRUCTIONS])
       csvStream.write(outputCsvRow)
     }

--- a/src/homedelivery/export.js
+++ b/src/homedelivery/export.js
@@ -19,7 +19,7 @@ const LAST_NAME = 'SoldToContact.LastName'
 const POSTAL_CODE = 'SoldToContact.PostalCode'
 const SUBSCRIPTION_NAME = 'Subscription.Name'
 const QUANTITY = 'RatePlanCharge.Quantity'
-const WORK_PHONE = 'SoldToContact.WorkPhone'
+// const WORK_PHONE = 'SoldToContact.WorkPhone'
 const DELIVERY_INSTRUCTIONS = 'SoldToContact.SpecialDeliveryInstructions__c'
 // output headers
 const CUSTOMER_REFERENCE = 'Customer Reference'

--- a/src/homedelivery/export.js
+++ b/src/homedelivery/export.js
@@ -13,13 +13,11 @@ import type { result, Input } from '../exporter'
 const ADDRESS_1 = 'SoldToContact.Address1'
 const ADDRESS_2 = 'SoldToContact.Address2'
 const CITY = 'SoldToContact.City'
-// const TITLE = 'SoldToContact.Title__c'
 const FIRST_NAME = 'SoldToContact.FirstName'
 const LAST_NAME = 'SoldToContact.LastName'
 const POSTAL_CODE = 'SoldToContact.PostalCode'
 const SUBSCRIPTION_NAME = 'Subscription.Name'
 const QUANTITY = 'RatePlanCharge.Quantity'
-// const WORK_PHONE = 'SoldToContact.WorkPhone'
 const DELIVERY_INSTRUCTIONS = 'SoldToContact.SpecialDeliveryInstructions__c'
 // output headers
 const CUSTOMER_REFERENCE = 'Customer Reference'
@@ -153,7 +151,7 @@ async function processSubs (downloadStream: ReadStream, deliveryDate: moment, st
       outputCsvRow[SENT_DATE] = sentDate
       outputCsvRow[DELIVERY_DATE] = formattedDeliveryDate
       outputCsvRow[CHARGE_DAY] = chargeDay
-      outputCsvRow[CUSTOMER_PHONE] = '' // row[WORK_PHONE] - Removed on 6 April 2021 due to no longer being necessary.
+      outputCsvRow[CUSTOMER_PHONE] = '' // Was row[WORK_PHONE]. Removed on 6-Apr-2021 due to no longer being necessary.
       outputCsvRow[ADDITIONAL_INFORMATION] = formatDeliveryInstructions(row[DELIVERY_INSTRUCTIONS])
       csvStream.write(outputCsvRow)
     }


### PR DESCRIPTION
## What does this change?
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

Removing the phone number from the Home Delivery fulfilment file as it's been confirmed that it is not used by the new delivery supplier, and it better respects customer privacy and reduces risk of an information security incident arising from a lost delivery manifest. The column needs to remain in the CSV file for compatibility, which supports blanks as phone numbers are already sparse.

## How to test
<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

Run the Lambda as per the instructions for tomorrow's file and confirm there are no phone numbers and the columns all align.

## How can we measure success?
<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

No phone numbers in the manifest.

## Have we considered potential risks?
<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

CEX have confirmed with the Head of Supply Chain that this can and should be removed.

## Images
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
N/A
