### PR TITLE
Don't fulfil cancelled gift GW subs

### DIFF
--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -83,6 +83,7 @@ async function queryZuora (deliveryDate, config: Config) {
           ) OR
           (
             Subscription.Status = 'Cancelled' AND
+            Subscription.ReaderType__c != 'Gift' AND
             Subscription.TermEndDate >= '${cutOffDate}'
           ) OR
           (

--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -83,7 +83,7 @@ async function queryZuora (deliveryDate, config: Config) {
           ) OR
           (
             Subscription.Status = 'Cancelled' AND
-            Subscription.ReaderType__c != 'Gift' AND
+            (Subscription.ReaderType__c != 'Gift' OR Subscription.ReaderType__c IS NULL) AND
             Subscription.TermEndDate >= '${cutOffDate}'
           ) OR
           (


### PR DESCRIPTION
There is a business rule that cancelled gift GW subs shouldn't be fulfilled even when the term end date falls within a future cutoff period.  This change to the fulfilment query reflects that rule.

Has been tested in the Code environment.
