### PR TITLE
Don't fulfil cancelled GW gift subs (attempt 2)

### DIFF
--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -83,7 +83,13 @@ async function queryZuora (deliveryDate, config: Config) {
           ) OR
           (
             Subscription.Status = 'Cancelled' AND
+            (Subscription.ReaderType__c != 'Gift' OR Subscription.ReaderType__c IS NULL) AND
             Subscription.TermEndDate >= '${cutOffDate}'
+          ) OR
+          (
+            Subscription.Status = 'Cancelled' AND
+            Subscription.ReaderType__c = 'Gift' AND
+            Subscription.TermEndDate >= '${formattedDeliveryDate}'
           ) OR
           (
            Subscription.Status = 'Active' AND  


### PR DESCRIPTION
This follows on from #165 
but this time gift subs in a 'cancellation pending' state are fulfilled up to the date when they are cancelled.

So the difference between gift and non-gift subs is that non-gifts have a cut-off period where an issue will be fulfilled if the term of the sub ends between two publication dates.