### PR TITLE
Generate fulfilment file for EU

### DIFF
--- a/__tests__/weekly/exporter.js
+++ b/__tests__/weekly/exporter.js
@@ -94,18 +94,18 @@ jest.mock('../../src/lib/config', () => ({
               prefix: 'TEST/salesforce_output/weekly/usa/'
             }
           },
-          FR: {
+          EU: {
             uploadFolder: {
               folderId: null,
-              name: 'Weekly_Pipeline_FR',
+              name: 'Weekly_Pipeline_EU',
               bucket: 'fulfilment-bucket-name',
-              prefix: 'TEST/fulfilments/Weekly_FR/'
+              prefix: 'TEST/fulfilments/Weekly_EU/'
             },
             downloadFolder: {
               folderId: 'folderId5',
-              name: 'Guardian Weekly (France)',
+              name: 'Guardian Weekly (EU)',
               bucket: 'fulfilment-bucket-name',
-              prefix: 'TEST/salesforce_output/weekly/fr/'
+              prefix: 'TEST/salesforce_output/weekly/eu/'
             }
           },
           NZ: {

--- a/__tests__/weekly/salesforce_uploader.js
+++ b/__tests__/weekly/salesforce_uploader.js
@@ -101,18 +101,18 @@ jest.mock('../../src/lib/config', () => ({
               prefix: 'TEST/salesforce_output/weekly/usa/'
             }
           },
-          FR: {
+          EU: {
             uploadFolder: {
-              folderId: 'folderId_FR_RELEASE',
-              name: 'Weekly_Pipeline_FR',
+              folderId: 'folderId_EU_RELEASE',
+              name: 'Weekly_Pipeline_EU',
               bucket: 'fulfilment-bucket-name',
-              prefix: 'TEST/fulfilments/Weekly_FR/'
+              prefix: 'TEST/fulfilments/Weekly_EU/'
             },
             downloadFolder: {
-              folderId: 'folderId_FR_SF',
-              name: 'Guardian Weekly (France)',
+              folderId: 'folderId_EU_SF',
+              name: 'Guardian Weekly (EU)',
               bucket: 'fulfilment-bucket-name',
-              prefix: 'TEST/salesforce_output/weekly/fr/'
+              prefix: 'TEST/salesforce_output/weekly/eu/'
             }
           },
           NZ: {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -40,13 +40,13 @@ export type Config = {
     homedelivery: uploadDownload,
     weekly: {
       NZ: uploadDownload,
-      FR: uploadDownload,
       VU: uploadDownload,
       AU: uploadDownload,
       UK: uploadDownload,
       CA: uploadDownload,
       CAHAND: uploadDownload,
       US: uploadDownload,
+      EU: uploadDownload,
       ROW: uploadDownload
     }
   }

--- a/src/weekly/WeeklyExporter.js
+++ b/src/weekly/WeeklyExporter.js
@@ -154,6 +154,7 @@ const euCountries: string[] = [
   'Bulgaria',
   'Croatia',
   'Cyprus',
+  'Czechia',
   'Czech Republic',
   'Denmark',
   'Estonia',

--- a/src/weekly/WeeklyExporter.js
+++ b/src/weekly/WeeklyExporter.js
@@ -1,7 +1,7 @@
 // @flow
 import moment from 'moment'
-import type { S3Folder } from './../lib/storage'
-import { getCanadianState, getUSState } from './../lib/states'
+import type { S3Folder } from '../lib/storage'
+import { getCanadianState, getUSState } from '../lib/states'
 import { csvFormatterForSalesforce } from '../lib/formatters'
 
 // input headers
@@ -145,5 +145,46 @@ export class USExporter extends WeeklyExporter {
 export class CaHandDeliveryExporter extends CaExporter {
   checkHandDelivery (handDeliveryValue: string): boolean {
     return handDeliveryValue.trim().toUpperCase() === 'YES'
+  }
+}
+
+const euCountries: string[] = [
+  'Austria',
+  'Belgium',
+  'Bulgaria',
+  'Croatia',
+  'Cyprus',
+  'Czech Republic',
+  'Denmark',
+  'Estonia',
+  'Finland',
+  'France',
+  'Germany',
+  'Greece',
+  'Hungary',
+  'Ireland',
+  'Italy',
+  'Latvia',
+  'Lithuania',
+  'Luxembourg',
+  'Malta',
+  'Netherlands',
+  'Poland',
+  'Portugal',
+  'Romania',
+  'Slovakia',
+  'Slovenia',
+  'Spain',
+  'Sweden'
+]
+
+export class EuExporter extends WeeklyExporter {
+  contains (arr: string[], s: string): boolean {
+    return arr.indexOf(s) > -1
+  }
+
+  useForRow (row: { [string]: string }): boolean {
+    // No need for trimmed or case-insensitive comparison as country field is from a picklist
+    return this.contains(euCountries, row[COUNTRY])
   }
 }

--- a/src/weekly/export.js
+++ b/src/weekly/export.js
@@ -2,12 +2,19 @@
 import * as csv from 'fast-csv'
 import moment from 'moment'
 import MultiStream from 'multistream'
-import { upload, createReadStream } from './../lib/storage'
+import { upload, createReadStream } from '../lib/storage'
 import { ReadStream } from 'fs'
-import { getStage, fetchConfig } from './../lib/config'
-import { generateFilename } from './../lib/Filename'
-import type { Filename } from './../lib/Filename'
-import { WeeklyExporter, CaExporter, CaHandDeliveryExporter, USExporter, UpperCaseAddressExporter } from './WeeklyExporter'
+import { getStage, fetchConfig } from '../lib/config'
+import { generateFilename } from '../lib/Filename'
+import type { Filename } from '../lib/Filename'
+import {
+  WeeklyExporter,
+  CaExporter,
+  CaHandDeliveryExporter,
+  USExporter,
+  UpperCaseAddressExporter,
+  EuExporter
+} from './WeeklyExporter'
 import type { result, Input } from '../exporter'
 import getStream from 'get-stream'
 
@@ -86,9 +93,9 @@ async function processSubs (downloadStream: ReadStream, deliveryDate: moment, st
     new CaHandDeliveryExporter('Canada', deliveryDate, config.fulfilments.weekly.CAHAND.uploadFolder),
     new USExporter('United States', deliveryDate, config.fulfilments.weekly.US.uploadFolder),
     new UpperCaseAddressExporter('Australia', deliveryDate, config.fulfilments.weekly.AU.uploadFolder),
-    new WeeklyExporter('France', deliveryDate, config.fulfilments.weekly.FR.uploadFolder),
     new UpperCaseAddressExporter('New Zealand', deliveryDate, config.fulfilments.weekly.NZ.uploadFolder),
     new UpperCaseAddressExporter('Vanuatu', deliveryDate, config.fulfilments.weekly.VU.uploadFolder),
+    new EuExporter('EU', deliveryDate, config.fulfilments.weekly.EU.uploadFolder),
     rowExporter
   ]
 

--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -38,18 +38,20 @@ async function queryZuora (deliveryDate, config: Config) {
       name: 'WeeklySubscriptions',
       query: `
       SELECT
-      Subscription.Name,
-      SoldToContact.Address1,
-      SoldToContact.Address2,
-      SoldToContact.City,
-      SoldToContact.Company_Name__c,
-      SoldToContact.Country,
-      SoldToContact.Title__c,
-      SoldToContact.FirstName,
-      SoldToContact.LastName,
-      SoldToContact.PostalCode,
-      SoldToContact.State,
-      Subscription.CanadaHandDelivery__c
+        Subscription.Name,
+        SoldToContact.Address1,
+        SoldToContact.Address2,
+        SoldToContact.City,
+        SoldToContact.Company_Name__c,
+        SoldToContact.Country,
+        SoldToContact.Title__c,
+        SoldToContact.FirstName,
+        SoldToContact.LastName,
+        SoldToContact.PostalCode,
+        SoldToContact.State,
+        Subscription.CanadaHandDelivery__c,
+        Account.MRR,
+        Account.Currency
       FROM
         RatePlanCharge
       WHERE 
@@ -104,18 +106,20 @@ async function queryZuora (deliveryDate, config: Config) {
       name: 'WeeklyIntroductoryPeriods',
       query: `
       SELECT
-      Subscription.Name,
-      SoldToContact.Address1,
-      SoldToContact.Address2,
-      SoldToContact.City,
-      SoldToContact.Company_Name__c,
-      SoldToContact.Country,
-      SoldToContact.Title__c,
-      SoldToContact.FirstName,
-      SoldToContact.LastName,
-      SoldToContact.PostalCode,
-      SoldToContact.State,
-      Subscription.CanadaHandDelivery__c
+        Subscription.Name,
+        SoldToContact.Address1,
+        SoldToContact.Address2,
+        SoldToContact.City,
+        SoldToContact.Company_Name__c,
+        SoldToContact.Country,
+        SoldToContact.Title__c,
+        SoldToContact.FirstName,
+        SoldToContact.LastName,
+        SoldToContact.PostalCode,
+        SoldToContact.State,
+        Subscription.CanadaHandDelivery__c,
+        Account.MRR,
+        Account.Currency
       FROM
         RatePlanCharge
       WHERE 

--- a/src/weekly/salesforce_uploader.js
+++ b/src/weekly/salesforce_uploader.js
@@ -41,14 +41,14 @@ export async function handler (input: WeeklyInput) {
   const s3ToSfName = (prefix: string) => `${prefix}_${sfFormattedDeliveryDate}_${uploadTimeStamp}.csv`
   const filesToUpload = [
     buildSourceAndDestination(config.fulfilments.weekly.NZ, s3ToSfName('GWNZ'), sourceFileName),
-    buildSourceAndDestination(config.fulfilments.weekly.FR, s3ToSfName('GWFR'), sourceFileName),
     buildSourceAndDestination(config.fulfilments.weekly.AU, s3ToSfName('GWAU'), sourceFileName),
     buildSourceAndDestination(config.fulfilments.weekly.CA, s3ToSfName('GWCA'), sourceFileName),
     buildSourceAndDestination(config.fulfilments.weekly.CAHAND, s3ToSfName('GWCA_HAND'), sourceFileName),
     buildSourceAndDestination(config.fulfilments.weekly.ROW, s3ToSfName('GWRW'), sourceFileName),
     buildSourceAndDestination(config.fulfilments.weekly.UK, s3ToSfName('GWUK'), sourceFileName),
     buildSourceAndDestination(config.fulfilments.weekly.US, s3ToSfName('GWUS'), sourceFileName),
-    buildSourceAndDestination(config.fulfilments.weekly.VU, s3ToSfName('GWVA'), sourceFileName)
+    buildSourceAndDestination(config.fulfilments.weekly.VU, s3ToSfName('GWVA'), sourceFileName),
+    buildSourceAndDestination(config.fulfilments.weekly.EU, s3ToSfName('GWEU'), sourceFileName)
   ]
   const result = await uploadFiles(filesToUpload, salesforce)
   console.log(`Successfully uploaded Guardian Weekly issue ${sfFormattedDeliveryDate} to Salesforce`)


### PR DESCRIPTION
The purpose of this change is to enable us to add a value field for EU deliveries for VAT purposes.

This change adds a new fulfilment file to the list to be generated, specifically for deliveries to all EU countries.
This supersedes the fulfilment file for France, which will no longer be generated after this change.
The RoW file should be smaller as a result, as all other EU countries were previously written there.

For this change to work, a corresponding change is required to the stage-specific config files stored in S3. 

Tested on Code.

See:
https://trello.com/c/Xcr8mZ0k/2457-goal-adding-unit-prices-to-guardian-weekly-subscriber-file
