### PR TITLE
Append unit price field to GW EU fulfilment rows

### DIFF
--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -38,18 +38,20 @@ async function queryZuora (deliveryDate, config: Config) {
       name: 'WeeklySubscriptions',
       query: `
       SELECT
-      Subscription.Name,
-      SoldToContact.Address1,
-      SoldToContact.Address2,
-      SoldToContact.City,
-      SoldToContact.Company_Name__c,
-      SoldToContact.Country,
-      SoldToContact.Title__c,
-      SoldToContact.FirstName,
-      SoldToContact.LastName,
-      SoldToContact.PostalCode,
-      SoldToContact.State,
-      Subscription.CanadaHandDelivery__c
+        Subscription.Name,
+        SoldToContact.Address1,
+        SoldToContact.Address2,
+        SoldToContact.City,
+        SoldToContact.Company_Name__c,
+        SoldToContact.Country,
+        SoldToContact.Title__c,
+        SoldToContact.FirstName,
+        SoldToContact.LastName,
+        SoldToContact.PostalCode,
+        SoldToContact.State,
+        Subscription.CanadaHandDelivery__c,
+        Account.MRR,
+        Account.Currency
       FROM
         RatePlanCharge
       WHERE 
@@ -104,18 +106,20 @@ async function queryZuora (deliveryDate, config: Config) {
       name: 'WeeklyIntroductoryPeriods',
       query: `
       SELECT
-      Subscription.Name,
-      SoldToContact.Address1,
-      SoldToContact.Address2,
-      SoldToContact.City,
-      SoldToContact.Company_Name__c,
-      SoldToContact.Country,
-      SoldToContact.Title__c,
-      SoldToContact.FirstName,
-      SoldToContact.LastName,
-      SoldToContact.PostalCode,
-      SoldToContact.State,
-      Subscription.CanadaHandDelivery__c
+        Subscription.Name,
+        SoldToContact.Address1,
+        SoldToContact.Address2,
+        SoldToContact.City,
+        SoldToContact.Company_Name__c,
+        SoldToContact.Country,
+        SoldToContact.Title__c,
+        SoldToContact.FirstName,
+        SoldToContact.LastName,
+        SoldToContact.PostalCode,
+        SoldToContact.State,
+        Subscription.CanadaHandDelivery__c,
+        Account.MRR,
+        Account.Currency
       FROM
         RatePlanCharge
       WHERE 


### PR DESCRIPTION
The purpose of this change is to indicate the value of deliveries at the EU border for VAT purposes.

This change adds new 'Unit price' and 'Currency' fields to the EU fulfilment file only.  The unit price is based on the [MRR](https://www.zuora.com/billing-topics/monthly-recurring-revenue-definition) value of the subscription.

For EU, header row looks like this:
`"Subscriber ID","Name","Company name","Address 1","Address 2","Address  3","Country","Post code","Copies","Unit price","Currency"`

Typical value row looks like this:
`"A-S12345678","kITbFBtqUoMmG9xAAyc kITbFBtqUoMmG9xAAyc","","kITbFBtqUoMmG9xAAyc","kITbFBtqUoMmG9xAAyc","kITbFBtqUoMmG9xAAyc","FRANCE","N19GU","1.0","4.71","EUR"`

Tested on Code.

See also:
* #170 
* https://trello.com/c/Xcr8mZ0k/2457-goal-adding-unit-prices-to-guardian-weekly-subscriber-file
