### PR TITLE
Use rate plan charge MRR, instead of account MRR, to calculate unit price of GW in EU

### DIFF
--- a/src/weekly/WeeklyExporter.js
+++ b/src/weekly/WeeklyExporter.js
@@ -17,8 +17,8 @@ const SUBSCRIPTION_NAME = 'Subscription.Name'
 const COMPANY_NAME = 'SoldToContact.Company_Name__c'
 const SHOULD_HAND_DELIVER = 'Subscription.CanadaHandDelivery__c'
 const STATE = 'SoldToContact.State'
-const MRR = 'Account.Mrr'
-const ACCOUNT_CURRENCY = 'Account.Currency'
+const MRR = 'RatePlanCharge.MRR'
+const ACCOUNT_CURRENCY = 'RatePlanCharge.TransactionCurrency'
 
 // output headers
 const CUSTOMER_REFERENCE = 'Subscriber ID'

--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -50,8 +50,7 @@ async function queryZuora (deliveryDate, config: Config) {
         SoldToContact.PostalCode,
         SoldToContact.State,
         Subscription.CanadaHandDelivery__c,
-        Account.MRR,
-        Account.Currency
+        MRR
       FROM
         RatePlanCharge
       WHERE 
@@ -118,8 +117,7 @@ async function queryZuora (deliveryDate, config: Config) {
         SoldToContact.PostalCode,
         SoldToContact.State,
         Subscription.CanadaHandDelivery__c,
-        Account.MRR,
-        Account.Currency
+        MRR
       FROM
         RatePlanCharge
       WHERE 


### PR DESCRIPTION
I found that when using the account monthly recurring revenue (MRR) it comes out as 0 for gift subs.

By using the rate plan charge MRR instead, all EU subs have a unit price.
The way that this MRR is calculated is explained [here](https://knowledgecenter.zuora.com/Billing/Subscriptions/Customer_Accounts/A_How_to_Manage_Customer_Accounts/E_Key_Metrics/B_Monthly_Recurring_Revenue).
The conversion of this to a unit value in this codebase hasn't changed.

In ZOQL, when you query for RatePlanCharge.MMR you get back in the result set these additional columns:
* RatePlanCharge.MRR
* RatePlanCharge.MRRHomeCurrency
* RatePlanCharge.MRRCurrencyRounding
* RatePlanCharge.ExchangeRate
* RatePlanCharge.ExchangeRateDate
* RatePlanCharge.ProviderExchangeRateDate
* RatePlanCharge.HomeCurrency
* RatePlanCharge.TransactionCurrency

most of which are redundant for our purposes apart from the MRR value itself and the transaction currency.

Tested in Code and in Prod.
