### PR TITLE
Apply a universal arbitrary value to Guardian Weeklies delivered to the EU

### DIFF
--- a/src/weekly/WeeklyExporter.js
+++ b/src/weekly/WeeklyExporter.js
@@ -17,8 +17,6 @@ const SUBSCRIPTION_NAME = 'Subscription.Name'
 const COMPANY_NAME = 'SoldToContact.Company_Name__c'
 const SHOULD_HAND_DELIVER = 'Subscription.CanadaHandDelivery__c'
 const STATE = 'SoldToContact.State'
-const MRR = 'RatePlanCharge.MRR'
-const ACCOUNT_CURRENCY = 'RatePlanCharge.TransactionCurrency'
 
 // output headers
 const CUSTOMER_REFERENCE = 'Subscriber ID'
@@ -206,14 +204,6 @@ export class EuExporter extends WeeklyExporter {
     return arr.indexOf(s) > -1
   }
 
-  round (n: number): number {
-    return Math.round(n * 100) / 100
-  }
-
-  monthlyValueToWeekly (n: number): number {
-    return n * 12 / 52
-  }
-
   useForRow (row: { [string]: string }): boolean {
     // No need for trimmed or case-insensitive comparison as country field is from a picklist
     return this.contains(euCountries, row[COUNTRY])
@@ -221,8 +211,15 @@ export class EuExporter extends WeeklyExporter {
 
   buildOutputCsv (row: { [string]: string }) {
     const outputCsvRow = super.buildOutputCsv(row)
-    outputCsvRow[UNIT_PRICE] = this.round(this.monthlyValueToWeekly(parseFloat(row[MRR])))
-    outputCsvRow[CURRENCY] = row[ACCOUNT_CURRENCY]
+    /*
+     * The arbitrary value of an individual Guardian Weekly
+     * for the purposes of checks at the EU border.
+     *
+     * This was determined by the most common MRR (* 12 / 52 to give a weekly value)
+     * of the batch of deliveries for the 24 Sep 2021 issue.
+     */
+    outputCsvRow[UNIT_PRICE] = 4.72
+    outputCsvRow[CURRENCY] = 'EUR'
     return outputCsvRow
   }
 }

--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -49,8 +49,7 @@ async function queryZuora (deliveryDate, config: Config) {
         SoldToContact.LastName,
         SoldToContact.PostalCode,
         SoldToContact.State,
-        Subscription.CanadaHandDelivery__c,
-        MRR
+        Subscription.CanadaHandDelivery__c
       FROM
         RatePlanCharge
       WHERE 
@@ -116,8 +115,7 @@ async function queryZuora (deliveryDate, config: Config) {
         SoldToContact.LastName,
         SoldToContact.PostalCode,
         SoldToContact.State,
-        Subscription.CanadaHandDelivery__c,
-        MRR
+        Subscription.CanadaHandDelivery__c
       FROM
         RatePlanCharge
       WHERE 


### PR DESCRIPTION
This changes the value we put against each published issue delivered to addresses in the EU.

Previously, we were applying the actual value of each subscription, calculated from its MRR.  This caused problems because some are in GBP rather than EUR.  It was decided that a universal arbitrary value would do just as well as individual calculations.

Tested in Code.
