### PR TITLE
Configure step function alarm to maintain state

### DIFF
--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -630,7 +630,7 @@ Resources:
       Period: 60
       EvaluationPeriods: 1
       Statistic: Sum
-      TreatMissingData: notBreaching
+      TreatMissingData: ignore
     DependsOn: FulfilmentStateMachine_[STAGE]
 
   HomeDeliveryUploadToSalesforceApiAlarm:


### PR DESCRIPTION
Between executions we want the alarm to stay in alarm if the latest execution failed.
Otherwise it returns to OK when the problem hasn't been resolved.

How alarms treat missing data is described [here](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarms-and-missing-data).
