### PR TITLE
[DRAFT] Fix duplicates in Home Delivery query

### DIFF
--- a/src/homedelivery/query.js
+++ b/src/homedelivery/query.js
@@ -37,6 +37,7 @@ async function queryZuora (deliveryDate, config: Config) {
      ProductRatePlanCharge.ProductType__c = 'Print ${deliveryDay}' AND
      Product.Name = 'Newspaper Delivery' AND
      RatePlanCharge.EffectiveStartDate <= '${formattedDate}' AND
+     RatePlanCharge.EffectiveStartDate != RatePlanCharge.EffectiveEndDate AND
      (
       ( 
         Subscription.Status = 'Active' AND Subscription.AutoRenew = true AND RatePlanCharge.EffectiveStartDate <= '${currentDate}' AND RatePlanCharge.EffectiveEndDate >= '${currentDate}'


### PR DESCRIPTION
## What does this change?
The query now ignores any rate plans that have no "span" yet (because the new term they are configured to span over hasn't been created yet).

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

1. Query for tomorrow before = 5574 subs, query for tomorrow after = 5572. 
2. Running `uniq` on the original file gives 5572 subs.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
