### PR TITLE
make HD fulfilment query detect an auto renewing sub more easily

### DIFF
--- a/src/homedelivery/query.js
+++ b/src/homedelivery/query.js
@@ -49,9 +49,9 @@ async function queryZuora (deliveryDate, config: Config) {
      (RatePlanCharge.MRR != 0 OR ProductRatePlan.FrontendId__c != 'EchoLegacy')`
     }
     /*
-    if the charge ends on or after the fulfilment date, it's a standard case so fall through.
-    
-    alternatively, if it ends on or after today it may be auto renewed by zuora before the fulfilment date. 
+    if the charge ends on or after the fulfilment date, it's a standard case so fulfil with no problem.
+
+    alternatively, if it ends on or after today it may be auto renewed by zuora before the fulfilment date.
     We need to predict whether zuora will auto renew based on the fields we have available.
     At present we predict based on the fields checked below the OR statement above, however this may be refined in future.
   */


### PR DESCRIPTION
This PR attempts to select rate plans more accurately based on whether they are likely to be auto renewed by zuora, in order to fulfil home delivery correctly.

## what was the issue?
We are seeing a problem where people who have had a price rise are appearing twice in the fulfilment file during the period where the fulfilment date was on or after the price rise date, but the fulfilment process was running on or before the price rise date.
For example, if someone's price rise was sat 9th july, the fulfilment runs for sat/sun/mon would be picked up on friday's run.  This means they would appear twice in those 3 files, and then return to once after that date.

## price rise
The way price rise works is it creates an amendment in Zuora which will remove the current/cheaper charge sometime in the future, and adds the more expensive charge on the day the current charge will end, see the [following example which underwent an echo-legacy price-rise](https://www.zuora.com/apps/Subscription.do?method=view&id=8a129ac28194121e0181948465a31ec2):

<img width="1515" alt="Screenshot 2022-07-12 at 10 26 38" src="https://user-images.githubusercontent.com/91546670/178458270-7e9bef1a-42e6-481e-ae78-e177a787f2e7.png">

 This means they are always covered by a charge and is correct.

## Auto renew
Subs auto renew on the term end date.  This means it looks like all charges are going to end on that date, then at some point on the day, the sub is renewed and the charges are extended.
Since we are running fulfilment in advance, we need to predict which charges will be extended, to avoid a gap in service.

## fulfilment - old way
see #81 for the change that added it
The old way of predicting was simply checking that the sub was active and auto renew, and the charge was active on the date the run happened (with a grace period of one day)
This means that the old charge would fulfil in every run triggered before it ended.
The new charge would trigger as soon as the fulfilment date was within range.
This means we would fulfil both the current charge (incorrectly) and the upcoming charge (correctly) in the lead up to the price rise.

We've translated the ZOQL query to Google Standard SQL to be run in BigQuery to play around with some data:

the bigQuery queries and other information can be found in this internal [google doc](https://docs.google.com/document/d/12U30tdaDpo7YK3UoS2KkbH1xavjx3OFyTiQdTflPLKE/edit#).

The output shows the two rateplans being pulled through:

<img width="743" alt="Screenshot 2022-07-12 at 10 43 31" src="https://user-images.githubusercontent.com/91546670/178468208-568731be-87be-4b90-9604-7c82e1b93651.png">

## fulfilment - new way
Since the old charge was "removed" zuora will not extend it, regardless of whether a renewal happens.
This means the fix was to [exclude any removed charges from the prediction](https://github.com/guardian/fulfilment-lambdas/pull/187/files#diff-be28699fe6b917ab44c7afe02ff3420c7fb8f8f1fb7b199349a7a52c05f0ce6bR45).
Also, since zuora dates are 00:00:01, we can change the condition to "less than" rather than "less than or equal".  The predictor should handle any case where fulfilment happens before the renewal is triggered.

## testing
This has been tested in zuora on 12th july POSTing to the batch query endpoint.
1. with a fulfilment date of tues 19th, the subscriptions are identical apart from the removal of duplicates.
1. with a fulcilment date of saturday 16th. the subscriptions are identical apart from the removal of duplicates.