### PR TITLE
Move GW subs with delivery country Japan, Thailand or Singapore to be in the Australia fulfilment file

### DIFF
--- a/__tests__/resources/input/weekly/exporter.json
+++ b/__tests__/resources/input/weekly/exporter.json
@@ -1,19 +1,19 @@
 {
-        "deliveryDate": "2017-10-27",
+        "deliveryDate": "2022-08-05",
         "type": "weekly",
-        "jobId": "2c92a0ff5f0ffc67015f25e3bd1f7d6b",
+        "jobId": "8a1291128234ae1801824288f38c16f4",
         "results": [
                 {
                         "queryName": "WeeklySubscriptions",
-                        "fileName": "WeeklySubscriptions_2017-10-27_2c92a0aa5f0fc118015f25e6186d709a.csv"
+                        "fileName": "WeeklySubscriptions_2022-08-05_8a128c2d823495800182428d686c4d09.csv"
                 },
                 {
                         "queryName": "WeeklyHolidaySuspensions",
-                        "fileName": "WeeklyHolidaySuspensions_2017-10-27_2c92a0aa5f0fc118015f25e7dca370ab.csv"
+                        "fileName": "WeeklyHolidaySuspensions_2022-08-05_8a128c2d823495800182428d6b794d0b.csv"
                 },
                 {
                         "queryName": "WeeklyIntroductoryPeriods",
-                        "fileName": "WeeklyIntroductoryPeriods_2017-10-27_2c92a0aa5f0fc118015f25e80b7770ac.csv"
+                        "fileName": "WeeklyIntroductoryPeriods_2022-08-05_8a128c2d8234958001824292f8d64f9f.csv"
                 }
         ]
 }

--- a/src/weekly/WeeklyExporter.js
+++ b/src/weekly/WeeklyExporter.js
@@ -44,15 +44,16 @@ export const outputHeaders = [
 ]
 
 export class WeeklyExporter {
-  country: string
+  countries: string[]
   sentDate: string
   formattedDeliveryDate: string
   chargeDay: string
   writeCSVStream: any
   folder: S3Folder
 
-  constructor (country: string, deliveryDate: moment, folder: S3Folder) {
-    this.country = country
+  constructor (countries: string[] | string, deliveryDate: moment, folder: S3Folder) {
+    this.countries = typeof countries === 'string' ? [countries] : countries
+
     this.writeCSVStream = csvFormatterForSalesforce(outputHeaders)
 
     this.sentDate = moment().format('DD/MM/YYYY')
@@ -62,7 +63,8 @@ export class WeeklyExporter {
   }
 
   useForRow (row: { [string]: string }): boolean {
-    return !!(row[COUNTRY] && row[COUNTRY] === this.country)
+    // No need for trimmed or case-insensitive comparison as country field is from a picklist
+    return this.countries.includes(row[COUNTRY])
   }
 
   formatAddress (name: string) {

--- a/src/weekly/export.js
+++ b/src/weekly/export.js
@@ -71,7 +71,6 @@ function getHolidaySuspensions (downloadStream: ReadStream): Promise<Set<string>
   })
 }
 
-// add description of problem
 const australiaFulfilmentCountries = ['Australia', 'Japan', 'Singapore', 'Thailand']
 
 /**

--- a/src/weekly/export.js
+++ b/src/weekly/export.js
@@ -71,6 +71,9 @@ function getHolidaySuspensions (downloadStream: ReadStream): Promise<Set<string>
   })
 }
 
+// add description of problem
+const australiaFulfilmentCountries = ['Australia', 'Japan', 'Singapore', 'Thailand']
+
 /**
  * Transfroms raw CSV from Zuora to expected CSV format, splits it per regions, and uploads it to S3 fulfilments folder.
  * If an exporter is not defined for a specific country, then it defaults to Rest of the world (ROW) fulfilment file.
@@ -92,7 +95,7 @@ async function processSubs (downloadStream: ReadStream, deliveryDate: moment, st
     new CaExporter('Canada', deliveryDate, config.fulfilments.weekly.CA.uploadFolder),
     new CaHandDeliveryExporter('Canada', deliveryDate, config.fulfilments.weekly.CAHAND.uploadFolder),
     new USExporter('United States', deliveryDate, config.fulfilments.weekly.US.uploadFolder),
-    new UpperCaseAddressExporter('Australia', deliveryDate, config.fulfilments.weekly.AU.uploadFolder),
+    new UpperCaseAddressExporter(australiaFulfilmentCountries, deliveryDate, config.fulfilments.weekly.AU.uploadFolder),
     new UpperCaseAddressExporter('New Zealand', deliveryDate, config.fulfilments.weekly.NZ.uploadFolder),
     new UpperCaseAddressExporter('Vanuatu', deliveryDate, config.fulfilments.weekly.VU.uploadFolder),
     new EuExporter('EU', deliveryDate, config.fulfilments.weekly.EU.uploadFolder),


### PR DESCRIPTION
 We are moving any Guardian Weekly subscriptions with delivery country Japan, Thailand or Singapore to be in the Australia Guardian Weekly fulfilment file, and removing them from the Rest Of World fulfilment file.

**Why?**
This is due to our delivery partners struggling with deliveries to these countries due to restrictions in the Russian airspace. We hope moving these subscriptions to be handled by our delivery partners based in Australia works.

![image](https://user-images.githubusercontent.com/91546670/181581540-ac336813-780e-47b2-bede-92b977bcc05c.png)

**Testing**

 We have ran the `exporter.js` script in PROD, and confirm the produced CSV files are correct:
 [CSV for AU](https://s3.console.aws.amazon.com/s3/object/fulfilment-export-prod?region=eu-west-1&prefix=fulfilments/Weekly_AU/2022-08-05_WEEKLY.csv)
[CSV for Rest Of World](https://s3.console.aws.amazon.com/s3/object/fulfilment-export-prod?region=eu-west-1&prefix=fulfilments/Weekly_ROW/2022-08-05_WEEKLY.csv)