### PR TITLE
migrate build from TC to GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
           yarn compile
           yarn test
           yarn dist
-      - run: yarn riffraff
       - name: AWS Auth
         uses: aws-actions/configure-aws-credentials@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v3
         with:
-          node-version: 14.17.x
+          node-version-file: .nvmrc
       - name: Yarn install
         uses: borales/actions-yarn@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,13 @@ jobs:
         uses: borales/actions-yarn@v4
         with:
           cmd: install
-      - run: yarn check
-      - run: yarn lint
-      - run: yarn flow
-      - run: yarn compile
-      - run: yarn test
-      - run: yarn dist
+      - run: |
+          yarn check
+          yarn lint
+          yarn flow
+          yarn compile
+          yarn test
+          yarn dist
       - run: yarn riffraff
       - name: AWS Auth
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,8 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: 'yarn'
-      - name: Yarn install
-        uses: borales/actions-yarn@v4
-        with:
-          cmd: install
       - run: |
+          yarn install --frozen-lockfile
           yarn check
           yarn lint
           yarn flow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+on: [push]
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 14.17.x
+      - name: Yarn install
+        uses: borales/actions-yarn@v4
+        with:
+          cmd: install
+      - run: yarn check
+      - run: yarn lint
+      - run: yarn flow
+      - run: yarn compile
+      - run: yarn test
+      - run: yarn dist
+      - run: yarn riffraff
+      - name: AWS Auth
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+          aws-region: eu-west-1
+      - name: Upload to riff-raff
+        uses: guardian/actions-riff-raff@v2
+        with:
+          configPath: riff-raff.yaml
+          projectName: MemSub::Fulfilment::Lambdas
+          buildNumberOffset: 755 # This is the last build number from TeamCity
+          contentDirectories: |
+            fulfilment-lambdas:
+              - cloudformation/cloudformation.yaml
+              - /home/runner/work/fulfilment-lambdas/fulfilment-lambdas/target/riffraff/fulfilment-lambdas/fulfilment-lambdas.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version-file: .nvmrc
+          cache: 'yarn'
       - name: Yarn install
         uses: borales/actions-yarn@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
           yarn compile
           yarn test
           yarn dist
+          # RiffRaff expects `fulfilment-lambdas.zip`, but `yarn compile` produces
+          # the `dist` direcrtory. We rename dist into fulfilment-lambdas before
+          # zipping.
+          mv dist fulfilment-lambdas
+          zip -r fulfilment-lambdas.zip fulfilment-lambdas
       - name: AWS Auth
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -36,4 +41,4 @@ jobs:
           contentDirectories: |
             fulfilment-lambdas:
               - cloudformation/cloudformation.yaml
-              - /home/runner/work/fulfilment-lambdas/fulfilment-lambdas/target/riffraff/fulfilment-lambdas/fulfilment-lambdas.zip
+              - fulfilment-lambdas.zip

--- a/package.json
+++ b/package.json
@@ -2,12 +2,7 @@
   "name": "fulfilment-lambdas",
   "version": "0.0.1",
   "description": "Lambdas to fulfil guardian subscriptions",
-  "isAwsLambda": true,
-  "projectName": "MemSub::Fulfilment::Lambdas",
-  "riffraffFile": "riff-raff.yaml",
-  "uploadArtefact": true,
   "buildDir": "dist",
-  "cloudformation": false,
   "devDependencies": {
     "@babel/cli": "^7.7.7",
     "@babel/core": "^7.7.7",
@@ -27,17 +22,14 @@
     "jest": "^24.9.0",
     "lambda-local": "^1.6.3",
     "mockdate": "^2.0.5",
-    "node-riffraff-artefact": "^2.0.1",
     "replace": "^1.1.1",
     "snazzy": "^8.0.0",
     "standard": "^14.3.1",
     "string-width": "^4.2.0"
   },
   "scripts": {
-    "riffraff-artefact": "./node_modules/.bin/riffraff-artefact",
     "dist": "mv node_modules node_modules_bak && yarn install --frozen-lockfile --production --modules-folder dist/node_modules > /dev/null && rm -rf node_modules/ && mv node_modules_bak node_modules",
     "compile": "babel src -d dist",
-    "riffraff": "VERBOSE=true ARTEFACT_PATH=$PWD yarn riffraff-artefact",
     "local": "yarn run:index && yarn run:hello",
     "cloudform": "yarn cloudform:prod & yarn cloudform:code",
     "cloudform:prod": "cp cloudformation/cloudformation.yaml cloudformation/prod.yaml && replace '_\\[STAGE\\]' 'PROD' cloudformation/prod.yaml",
@@ -55,7 +47,7 @@
     "clean": "rm -rf dist && rm -rf target && rm -f cloudformation/prod.yaml && rm -f  cloudformation/code.yaml",
     "lint": "standard | snazzy",
     "test": "jest --runInBand",
-    "tc": "yarn install && yarn check && yarn flow && yarn compile && yarn dist && yarn riffraff",
+    "tc": "yarn install && yarn check && yarn flow && yarn compile && yarn dist",
     "testOnly": "jest -t 'should generate correct fulfilment file'"
   },
   "dependencies": {


### PR DESCRIPTION
This migrate the build of this repository software from Team City to GHA. 

The existing script is here: https://github.com/guardian/fulfilment-lambdas/blob/62c3893667f3ab39327b568b034c55ff01f6ecdd/build-tc.sh

Last build on Team City:

<img width="1206" alt="Screenshot 2023-08-01 at 22 43 47" src="https://github.com/guardian/fulfilment-lambdas/assets/6035518/3c402fa6-4b4d-4a2e-8af5-52f7d6f70fe8">

.

755 was the last build made by TC. After which I disabled the TC trigger. 774 was the first GHA build seen by Riff-Raff.

.

<img width="879" alt="01 Screenshot 2023-08-01 at 22 22 01" src="https://github.com/guardian/fulfilment-lambdas/assets/6035518/1eee60e4-782a-4f7a-8b9e-aa707b5d00e5">

.

<img width="581" alt="02 Screenshot 2023-08-01 at 22 21 28" src="https://github.com/guardian/fulfilment-lambdas/assets/6035518/bcff25b8-4636-4e4b-a5e1-f194b3a84fab">

.

<img width="1218" alt="Screenshot 2023-08-01 at 23 03 37" src="https://github.com/guardian/fulfilment-lambdas/assets/6035518/4893bcc1-f534-43eb-88be-c28e457e028c">


