### PR TITLE
better generation of artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,11 @@ jobs:
           yarn test
           yarn dist
           # RiffRaff expects `fulfilment-lambdas.zip`, but `yarn compile` produces
-          # the `dist` direcrtory. We rename dist into fulfilment-lambdas before
-          # zipping.
-          mv dist fulfilment-lambdas
-          zip -r fulfilment-lambdas.zip fulfilment-lambdas
+          # the `dist` directory. 
+          # Note that the zipped will be: dist/fulfilment-lambdas.zip
+          pushd dist
+          zip -r fulfilment-lambdas.zip ./*
+          popd
       - name: AWS Auth
         uses: aws-actions/configure-aws-credentials@v2
         with:
@@ -41,4 +42,4 @@ jobs:
           contentDirectories: |
             fulfilment-lambdas:
               - cloudformation/cloudformation.yaml
-              - fulfilment-lambdas.zip
+              - dist/fulfilment-lambdas.zip


### PR DESCRIPTION
When we did https://github.com/guardian/fulfilment-lambdas/pull/198 we used 

```
mv dist fulfilment-lambdas
zip -r fulfilment-lambdas.zip fulfilment-lambdas
```

Which caused the following surprising problem 

![unnamed](https://github.com/guardian/fulfilment-lambdas/assets/6035518/958ca67e-7903-4d42-91fa-4fd53803dc25)

We correct that problem using an idea from here: https://github.com/guardian/email-mvt/blob/main/.github/workflows/email-mvt-archive-build.yml#L55 via @paulbrown1982 

to then become 
```
pushd dist
zip -r fulfilment-lambdas.zip ./*
popd
```

