### PR TITLE
feat: report alarms to alarms-handler

### DIFF
--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -609,6 +609,9 @@ Resources:
   FulfilmentStateMachineAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources
+    Tags:
+      - Key: "App"
+        Value: "fulfilment-lambdas"
     Properties:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
@@ -637,6 +640,9 @@ Resources:
   HomeDeliveryUploadToSalesforceApiAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources
+    Tags:
+      - Key: "App"
+        Value: "fulfilment-lambdas"
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
@@ -667,6 +673,9 @@ Resources:
   GuardianWeeklyUploadToSalesforceLambdaAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources
+    Tags:
+      - Key: "App"
+        Value: "fulfilment-lambdas"
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}

--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -609,9 +609,6 @@ Resources:
   FulfilmentStateMachineAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources
-    Tags:
-      - Key: "App"
-        Value: "fulfilment-lambdas"
     Properties:
       AlarmActions:
       - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
@@ -640,9 +637,6 @@ Resources:
   HomeDeliveryUploadToSalesforceApiAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources
-    Tags:
-      - Key: "App"
-        Value: "fulfilment-lambdas"
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
@@ -673,9 +667,6 @@ Resources:
   GuardianWeeklyUploadToSalesforceLambdaAlarm:
     Type: AWS::CloudWatch::Alarm
     Condition: CreateProdResources
-    Tags:
-      - Key: "App"
-        Value: "fulfilment-lambdas"
     Properties:
       AlarmActions:
         - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}

--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -611,7 +611,7 @@ Resources:
     Condition: CreateProdResources
     Properties:
       AlarmActions:
-      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+      - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
       AlarmName: !Join
         - ' '
         - - !FindInMap [ Constants, Alarm, Urgent ]
@@ -639,7 +639,7 @@ Resources:
     Condition: CreateProdResources
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
       AlarmName: !Join
         - ' '
         - - !FindInMap [ Constants, Alarm, Urgent ]
@@ -669,7 +669,7 @@ Resources:
     Condition: CreateProdResources
     Properties:
       AlarmActions:
-        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:fulfilment-dev
+        - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:alarms-handler-topic-${Stage}
       AlarmName: !Join
         - ' '
         - - !FindInMap [ Constants, Alarm, Urgent ]

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -21,5 +21,6 @@ deployments:
 #  fulfilment-node-stub-cloudformation:
 #  N.B.: cloudformation deployment not quite finished
 #   type: cloud-formation
+#     app: fulfilment-lambdas
 #     parameters:
 #       templatePath: 'cloudformation/cloudformation.yaml'


### PR DESCRIPTION
- [Uses the generalised alarm-handler](https://github.com/guardian/support-service-lambdas/pull/2273)
- `App` tag was added manually as the cloud-formation deployment is "not quite finished"