### PR TITLE
feat: query ProductType__c in ProductRatePlanCharge to include GW nested in new 3-tier subscriptions

### DIFF
--- a/src/weekly/query.js
+++ b/src/weekly/query.js
@@ -53,7 +53,7 @@ async function queryZuora (deliveryDate, config: Config) {
       FROM
         RatePlanCharge
       WHERE 
-        Product.ProductType__c = 'Guardian Weekly' AND
+        ProductRatePlanCharge.ProductType__c = 'Guardian Weekly' AND
         RatePlan.Name != 'Guardian Weekly 6 Issues' AND
         RatePlan.Name != 'Guardian Weekly 12 Issues' AND
         RatePlan.Name != 'GW Oct 18 - Six for Six - ROW' AND


### PR DESCRIPTION
## What does this change?

[Trello](https://trello.com/c/p5yORFGq/895-change-fulfilment-lambdas-to-look-for-product-type-on-charge)

This updates the query for the Guardian Weekly fulfilment.

We now look for `ProductRatePlanCharge.ProductType__c = 'Guardian Weekly'` rather than `Product.ProductType__c = 'Guardian Weekly'` since Guardian Weekly charges are nested in the new 3-tier subscriptions.

We have checked the output diffs on CODE and they look correct as the output with the new query contains all rows of the previous query plus the new subscriptions containing the new 3-tier products.

<img width="1312" alt="Screenshot 2024-06-17 at 14 18 09" src="https://github.com/guardian/fulfilment-lambdas/assets/39066365/6062f3d1-d102-4787-abb9-5d3a23813aa2">
