### PR TITLE
fix: have all handlers at the root of the src folder

### DIFF
--- a/__tests__/weekly/salesforce_uploader.ts
+++ b/__tests__/weekly/salesforce_uploader.ts
@@ -1,5 +1,5 @@
 /* eslint-env jest */
-import { handler } from '../../src/weekly/salesforce_uploader';
+import { handler } from '../../src/weekly_salesforce_uploader';
 
 var MockDate = require('mockdate');
 // mock current date

--- a/cloudformation/cloudformation.yaml
+++ b/cloudformation/cloudformation.yaml
@@ -239,7 +239,7 @@ Resources:
       FunctionName:
           !Sub weekly-fulfilmentUploader-${Stage}
       Description: "upload Guardian Weekly fulfilment files to salesforce"
-      Handler: "weekly/salesforce_uploader.handler"
+      Handler: "weekly_salesforce_uploader.handler"
       Role: !GetAtt [ FulfilmentWorkersLambdaRole, Arn ]
       Code:
         S3Bucket: fulfilment-lambdas-dist

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
 		"typescript": "^5.5.3"
 	},
 	"scripts": {
-		"build": "esbuild --bundle --platform=node --target=node20 --outdir=dist src/*.ts src/**/*.ts",
+		"build": "esbuild --bundle --platform=node --target=node20 --outdir=dist src/*.ts",
 		"package": "yarn type-check && yarn lint && yarn check-formatting && yarn test && yarn build && cd dist && zip -qr fulfilment-lambdas.zip ./*.js",
 		"check-formatting": "prettier --check **/*.ts **.ts",
 		"fix-formatting": "prettier --write **/*.ts **.ts",
@@ -47,7 +47,7 @@
 		"run:weekly:querier": "lambda-local -l dist/querier.js -e __tests__/resources/input/weekly/querier.json -h handler -P ~/.aws/credentials -p membership -r eu-west-1 -t 30 -E {\\\"Stage\\\":\\\"CODE\\\"}",
 		"run:hd:fetcher": "lambda-local -l dist/fetcher.js -e __tests__/resources/input/homedelivery/fetcher.json -h handler -P ~/.aws/credentials -p membership -r eu-west-1 -t 30 -E {\\\"Stage\\\":\\\"CODE\\\"}",
 		"run:weekly:fetcher": "lambda-local -l dist/fetcher.js -e __tests__/resources/input/weekly/fetcher.json -h handler -P ~/.aws/credentials -p membership -r eu-west-1 -t 30 -E {\\\"Stage\\\":\\\"CODE\\\"}",
-		"run:weekly:uploader": "lambda-local -l dist/weekly/salesforce_uploader.js -e __tests__/resources/input/weekly/salesforce_uploader.json -h handler -P ~/.aws/credentials -p membership -r eu-west-1 -t 30 -E {\\\"Stage\\\":\\\"CODE\\\"}",
+		"run:weekly:uploader": "lambda-local -l dist/weekly_salesforce_uploader.js -e __tests__/resources/input/weekly_salesforce_uploader.json -h handler -P ~/.aws/credentials -p membership -r eu-west-1 -t 30 -E {\\\"Stage\\\":\\\"CODE\\\"}",
 		"run:sf": "lambda-local -l dist/salesforce_downloader.js -e __tests__/resources/input/input.json -h handler -P ~/.aws/credentials -p membership -r eu-west-1 -t 30 -E {\\\"Stage\\\":\\\"CODE\\\"}",
 		"run:sfup": "lambda-local -l dist/salesforce_uploader.js -e __tests__/resources/input/upload.json -h handler -P ~/.aws/credentials -p membership -r eu-west-1 -t 30 -E {\\\"Stage\\\":\\\"CODE\\\"}",
 		"run:checker": "lambda-local -l dist/checker.js -e __tests__/resources/input/checker.json -h handler -P ~/.aws/credentials -p membership -r eu-west-1 -t 30 -E {\\\"Stage\\\":\\\"CODE\\\"}",

--- a/src/weekly_salesforce_uploader.ts
+++ b/src/weekly_salesforce_uploader.ts
@@ -1,11 +1,11 @@
-import { fetchConfig } from '../lib/config';
-import { uploadFiles } from '../lib/S3ToSalesforceUploader';
-import { authenticate } from '../lib/salesforceAuthenticator';
-import type { uploadDownload } from '../lib/config';
-import type { UploadInfo } from '../lib/S3ToSalesforceUploader';
+import { fetchConfig } from './lib/config';
+import { uploadFiles } from './lib/S3ToSalesforceUploader';
+import { authenticate } from './lib/salesforceAuthenticator';
+import type { uploadDownload } from './lib/config';
+import type { UploadInfo } from './lib/S3ToSalesforceUploader';
 import moment from 'moment';
-import { getDeliveryDate } from './WeeklyInput';
-import type { WeeklyInput } from './WeeklyInput';
+import { getDeliveryDate } from './weekly/WeeklyInput';
+import type { WeeklyInput } from './weekly/WeeklyInput';
 
 function buildSourceAndDestination(
 	upDown: uploadDownload,


### PR DESCRIPTION
## What does this change?

This fixes a bug introduced during the conversion of the build process from JavaScript to TypeScript.

The project has 7 lambda handlers. Six of them are in the root `src` folder. One of them (the one failing) was inside the `weekly` folder, which was not picked up by the `package` script.

The solution I went for is to move that handler to the root, for consistency.