### PR TITLE
fix(deps): bump lodash from 4.17.23 to 4.18.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
 		"eslint": "^9.37.0",
 		"jest": "^29.7.0",
 		"lambda-local": "^1.6.3",
-		"lodash": "^4.17.23",
+		"lodash": "^4.18.1",
 		"mockdate": "^2.0.5",
 		"prettier": "^3.3.3",
 		"replace": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,8 +104,8 @@ importers:
         specifier: ^1.6.3
         version: 1.7.4
       lodash:
-        specifier: ^4.17.23
-        version: 4.17.23
+        specifier: ^4.18.1
+        version: 4.18.1
       mockdate:
         specifier: ^2.0.5
         version: 2.0.5
@@ -2198,8 +2198,8 @@ packages:
   lodash.uniq@4.5.0:
     resolution: {integrity: sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==}
 
-  lodash@4.17.23:
-    resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
   logform@2.7.0:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
@@ -5369,7 +5369,7 @@ snapshots:
 
   lodash.uniq@4.5.0: {}
 
-  lodash@4.17.23: {}
+  lodash@4.18.1: {}
 
   logform@2.7.0:
     dependencies:


### PR DESCRIPTION
## What does this change?

Bumps `lodash` (devDependency) from 4.17.23 to 4.18.1 to resolve the last 2 open Dependabot security alerts:

- #86 — Prototype Pollution via array path bypass in `_.unset` and `_.omit` (medium)
- #87 — Code Injection via `_.template` imports key names (high)

## How has this change been tested?

All CI gates pass locally:
- type-check: passed
- lint: passed (0 errors)
- check-formatting: passed
- test: passed (29/29)
- build: passed

## How can we measure success?

The remaining 2 Dependabot security alerts should close automatically once merged, bringing the repository to 0 open alerts.

## Have we considered potential risks?

Low risk. Patch-level bump on a devDependency only — does not affect production bundle.