### PR TITLE
chore(deps): upgrade pnpm from v9 to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "fulfilment-lambdas",
 	"version": "0.0.1",
 	"description": "Lambdas to fulfil guardian subscriptions",
-	"packageManager": "pnpm@9.12.3",
+	"packageManager": "pnpm@10.33.4",
 	"buildDir": "dist",
 	"devDependencies": {
 		"@babel/cli": "^7.7.7",


### PR DESCRIPTION
## What does this change?

Upgrades pnpm from v9.12.3 to v10.33.4. Only the `packageManager` field in `package.json` needs updating — the CI workflow uses `corepack enable` and `pnpm/action-setup@v4` without an explicit `version:` field, so the version is read from `packageManager`. The lockfile format `9.0` is shared between v9 and v10, so no regeneration was needed.

The motivation comes from DevX security: in response to the recent axios supply chain attack, pnpm v9 was flagged as insecure-by-default because it allows `postinstall` scripts of dependencies to run automatically. Starting from v10, pnpm blocks them by default, requiring an explicit `pnpm.onlyBuiltDependencies` allowlist for legitimate cases. See pnpm's docs on this mitigation: https://pnpm.io/supply-chain-security#block-risky-postinstall-scripts

## How has this change been tested?

All CI gates from `.github/workflows/ci.yml` were run locally with pnpm v10.33.4:

- `pnpm install --frozen-lockfile`
- `pnpm package` (which chains `type-check`, `lint`, `check-formatting`, `test`, `build`)

29 tests passed, type-check and lint clean, prettier formatting clean, esbuild bundle produced for all Lambda entrypoints.

pnpm v10 reported two ignored `postinstall` scripts (`aws-sdk@2.1693.0`, `esbuild@0.25.12`); neither caused any failure — the build (which uses esbuild) succeeded without an allowlist, which is the behaviour we want from this upgrade.

## How can we measure success?

CI on this branch should pass with pnpm v10 (`corepack enable` reads `packageManager` from `package.json`). No behavioural change in any Lambda is expected.

## Have we considered potential risks?

- **Lockfile compatibility**: pnpm v10 uses lockfile format `9.0`, same as v9. The existing `pnpm-lock.yaml` is reused as-is.
- **Postinstall scripts blocked**: desired behaviour. If a dependency ever genuinely needs its postinstall (e.g. a future native-binary dep), CI will surface a build failure and we'll add it to `pnpm.onlyBuiltDependencies`.
- **No code changes**: configuration only — one line.